### PR TITLE
Retry on busy message box, Xorg video drives and README.md tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,6 @@ See [Translations HOWTO](https://github.com/rescuezilla/rescuezilla/wiki/Transla
 <a href="docs/images/screenshot.select.backup.destination.drive.png"><img width=245 height=183 src="docs/images/screenshot.select.backup.destination.drive.png" alt="Save to hard drive, network shared folder, or FTP server"></a>
 <a href="docs/images/screenshot.boot.menu.png"><img width=245 height=183 src="docs/images/screenshot.boot.menu.png" alt="Easy point and click interface anyone can use"></a>
 
-## Downloads
-
-Rescuezilla releases (including the old, out-of-date _Redo Backup and Recovery_ ISO images) can be found at the GitHub release page: https://github.com/rescuezilla/rescuezilla/releases
-
-Please consult the [FAQ](https://rescuezilla.com/help.html) and the [limitations page](https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Limitations) to determine if Rescuezilla is right for you.
-
-Please consider becoming a [Patreon](https://www.patreon.com/rescuezilla) to help fund Rescuezilla's continued development!
-
-## Future development
-
-Rescuezilla features are prioritized according to the [roadmap](https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Project-Roadmap). Please consider becoming a [Patreon](https://www.patreon.com/rescuezilla) to help fund Rescuezilla's continued development!
-
 ## History
 
 Below table shows an abridged history of Rescuezilla. See the CHANGELOG for more information.
@@ -65,4 +53,16 @@ Below table shows an abridged history of Rescuezilla. See the CHANGELOG for more
 
 See [Building ISO image](docs/build_instructions/BUILD.ISO.IMAGE.md)
 
-[Download pre-built Rescuezilla ISO images on the GitHub Releases page](https://github.com/rescuezilla/rescuezilla/releases)
+## Future development
+
+Rescuezilla features are prioritized according to the [roadmap](https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Project-Roadmap). Please consider becoming a [Patreon](https://www.patreon.com/rescuezilla) to help fund Rescuezilla's continued development!
+
+## Limitations and support
+
+Please consult the [FAQ](https://rescuezilla.com/help.html) and the [limitations page](https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Limitations) to determine if Rescuezilla is right for you.
+
+## Downloads
+
+[Download Rescuezilla ISO images on the GitHub Release page](https://github.com/rescuezilla/rescuezilla/releases)
+
+If you want the project to continue, please consider [supporting the project on Patreon to help fund Rescuezilla's continued development](https://www.patreon.com/rescuezilla)!

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Rescuezilla (formerly _Redo Backup and Recovery_) is an extremely easy-to-use gr
 
 Rescuezilla can be booted on any PC or Mac from a USB stick, or CD, and uses the exact same reliable, battle-tested ‘partclone’ utility that Clonezilla uses. For many people, the alternative open-source tools Clonezilla and SysRescueCD, are intimidating and difficult to use, so Rescuezilla provides an easy-to-use graphical environment like the leading commercial tools, Norton Ghost and Acronis True Image.
 
+Rescuezilla [relies on Patreon support](https://www.patreon.com/rescuezilla) for continued development.
+
 ## Features
 
 * Simple graphical environment anyone can use
@@ -55,7 +57,7 @@ See [Building ISO image](docs/build_instructions/BUILD.ISO.IMAGE.md)
 
 ## Future development
 
-Rescuezilla features are prioritized according to the [roadmap](https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Project-Roadmap). Please consider becoming a [Patreon](https://www.patreon.com/rescuezilla) to help fund Rescuezilla's continued development!
+Rescuezilla features are prioritized according to the [roadmap](https://github.com/rescuezilla/rescuezilla/wiki/Rescuezilla-Project-Roadmap). Please consider becoming a [Patreon to help fund Rescuezilla's continued development](https://www.patreon.com/rescuezilla)!
 
 ## Limitations and support
 

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -56,7 +56,7 @@ apt-get install --yes --no-install-recommends discover \
                                               xinit \
                                               openbox \
                                               xserver-xorg-hwe-18.04 \
-                                              xserver-xorg-video-vesa-hwe-18.04 \
+                                              xserver-xorg-video-all-hwe-18.04 \
                                               x11-xserver-utils \
                                               xterm \
                                               network-manager-gnome \

--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -438,7 +438,8 @@ sub update_backup_progress {
     system("echo $tool > $dest/$file.partclone.command.part$pn");
     set_status(loc("Preparing to create backup of Drive [_1], Part [_2]...",$dn, $pn));
     print "*** ".loc("Processing [_1] ([_2]) using [_3]...",$part,$fs,$tool)."\n";
-    system("umount /dev/$part 2>&1");
+    umount_warn_on_busy("/dev/$part");
+
     my $backup_cmd = "( $tool $extra_args -F -L /$dest/$file"."_part$pn"."_partclone.log -s /dev/$part | pigz -c --fast | split -d -a 3 -b 2048m - /$dest/$file"."_part$pn. ) 2>&1 |";
     print "*** ".loc("Executing: ")."$backup_cmd\n";
     open $PROGRESS, "$backup_cmd";
@@ -556,7 +557,7 @@ sub update_backup_progress {
         # Unmount stuff
         system("sync");
         sleep(0.5);
-        system("umount ".MOUNT_POINT);
+        umount_warn_on_busy(MOUNT_POINT);
         beeper('done');
         my $elapsed = sprintf("%.1f", (time()-$status{'start'})/60);
         message_box(loc("Backup image saved in [_1] minutes.", $elapsed));
@@ -814,7 +815,7 @@ sub do_restore {
     on_main_app_destroy();
     die("Aborting.\n");
   }
-  system("umount /mnt/$dest_drive?* 2>&1");
+  umount_warn_on_busy("/mnt/$dest_drive?*");
   sleep(0.5);
   print "*** ".loc("Writing MBR to [_1]",$dest_drive)."\n";
   set_status(loc("Writing master boot record to destination drive..."));
@@ -835,7 +836,7 @@ sub do_restore {
   sleep(0.5);
   print "*** ".loc("Reloading partition table from [_1]",$dest_drive)."\n";
   set_status(loc("Reloading new partition table from destination drive..."));
-  system("umount /dev/$dest_drive?* 2>&1");
+  umount_warn_on_busy("/dev/$dest_drive?*");
   system("partprobe /dev/$dest_drive");
   sleep(1);
   $status{'start'} = time();
@@ -890,10 +891,10 @@ sub update_restore_progress {
   my $src_mbr = $src.'.mbr';
   # See if the filehandle is open
   if (!defined($PROGRESS)) {
-    system("umount /mnt/$dest_drive$pn 2>&1; dd if=/dev/zero of=/dev/$dest_drive$pn bs=1K count=1000; sync");
+    umount_warn_on_busy("/dev/$dest_drive$pn");
+    umount_warn_on_busy("/dev/$part");
+    system("dd if=/dev/zero of=/dev/$dest_drive$pn bs=1K count=1000; sync");
     set_status(loc("Preparing to restore backup for Drive [_1], Part [_2]...",$dn,$pn));
-    system("umount /dev/$dest_drive$pn 2>&1");
-    system("umount /dev/$part 2>&1");
     my $backup_version = `cat /$src.rescuezilla.backup_version`;
     chomp($backup_version);
     print loc("Detected backup created with [_1]",$backup_version)."\n";
@@ -1033,7 +1034,7 @@ sub update_restore_progress {
         set_status(loc("Rewriting master boot record to destination drive..."));
         system("dd of=/dev/$dest_drive if=$src_mbr bs=32768 count=1; sync;");
         sleep(0.5);
-        system("umount ".MOUNT_POINT);
+        umount_warn_on_busy(MOUNT_POINT);
         my $elapsed = sprintf("%.1f", (time()-$status{'start'})/60);
         print ">>> ".loc("Operation complete.")."\n";
         set_status(loc("Restore complete."));
@@ -1070,11 +1071,26 @@ sub get_confirmation {
   # Get confirmation from a yes/no dialog
   our $builder;
   my $question = loc("Are you sure?");
-	if (defined($_[0])) { $question = $_[0]; }
+  if (defined($_[0])) { $question = $_[0]; }
   my $dialog = Gtk2::MessageDialog->new($builder->get_object('main_app'),
     'destroy-with-parent',
     'warning', # message type
     'yes-no', # which set of buttons?
+    $question);
+  my $response = $dialog->run;
+  $dialog->destroy;
+  return $response;
+}
+
+sub get_retry_confirmation {
+  # Get user response to potentially fatal error
+  our $builder;
+  my $question = loc("Are you sure?");
+  if (defined($_[0])) { $question = $_[0]; }
+  my $dialog = Gtk2::MessageDialog->new($builder->get_object('main_app'),
+    'destroy-with-parent',
+    'warning', # message type
+    'ok-cancel', # which set of buttons?
     $question);
   my $response = $dialog->run;
   $dialog->destroy;
@@ -1270,7 +1286,7 @@ sub mount_data {
   our %shares;
   our %status;
   system("mkdir -p ".MOUNT_POINT);
-  system("umount ".MOUNT_POINT." 2>&1");
+  umount_warn_on_busy(MOUNT_POINT);
   our $builder;
   for ($status{'mount_type'}) {
     if (/DEV/) {
@@ -1329,6 +1345,74 @@ sub mount_data {
   my $mp = MOUNT_POINT;
   my $mounted = `mount | grep '$mp' | wc -l`;
   return $mounted;
+}
+
+sub umount_partition {
+  # Attempts to unmount a partition and returns whether the partition is still mounted.
+  # Checking whether the drive is still mounted is required because both umount'ing an
+  # already unmounted drive, and umount'ing a busy drive return the exit code 32,
+  # which means "mount failure". The `findmnt` application is a portable way to
+  # delineate this two situations.
+  #
+  # Input arguments:
+  #   0, mount_point: The device node (or "/dev/sda") or mount point ("/mnt/test_path").
+  #                   Note: Wildcards and asterisks *are* supported.
+  #
+  # Returns:
+  #   list of partitions which are still mounted. Success if length 0.
+
+  my $mount_point = $_[0];
+
+  # Attempt to unmount the mount point.
+  system("umount ".$mount_point." 2>&1");
+
+  # Use findmnt to robustly check whether the provided path (which may contain wildcard
+  # characters) is mounted on Linux.
+  my @partition_list = glob("$mount_point");
+  my @still_mounted = ();
+  foreach my $partition (@partition_list) {
+    # Extract the "/dev/..." device node string from the input (which may be a mount point)
+    my $device_node = `findmnt --raw --noheadings --output SOURCE \'$partition\'`;
+    chomp($device_node);
+    if ($device_node ne '') {
+      push @still_mounted, $device_node;
+    }
+  }
+  return @still_mounted;
+} 
+
+sub umount_warn_on_busy {
+  # Unmounts a partition. If the partition is busy, it will warn the user and
+  # allow the user to either fix the problem or abort the application.
+  #
+  # Input arguments:
+  #   0, mount_point: The device node (or "/dev/sda") or mount point ("/mnt/test_path").
+  #                   Note: Wildcards and asterisks *are* supported.
+
+  my $mount_point = $_[0];
+  # Keep looping until the busy partition list is empty
+  my @busy_device_node_list = umount_partition("$mount_point");
+  print "The length of the busy partition is ".scalar(@busy_device_node_list)." \n";
+  while (scalar(@busy_device_node_list) != 0) {
+    my $partition_pretty_string = "";
+    foreach my $device_node (@busy_device_node_list) {
+      # Retrieve the device node and mount path (caller could have provided either)
+      my $mount_path = `findmnt --raw --noheadings --output TARGET \'$device_node\'`;
+      chomp($mount_path);
+      $partition_pretty_string = $partition_pretty_string.$device_node.": ".$mount_path."\n";
+      print loc("Unable to unmount partition: [_1]", $partition_pretty_string)."\n";
+    }
+    my $partition_busy_msg = loc("Partition(s) were unable to be unmounted. Please close any applications using the following partition(s) and click OK.\n\n [_1]",$partition_pretty_string);
+    my $response = get_retry_confirmation($partition_busy_msg);
+    if ($response eq 'cancel') {
+      $response = get_confirmation(loc("Are you sure you want to exit?"));
+      if ($response eq 'yes') {
+        on_main_app_destroy();
+        die(loc("Aborting.")."\n");
+      }
+    }
+    @busy_device_node_list = umount_partition("$mount_point");
+  }
 }
 
 sub set_usb_dropdown {


### PR DESCRIPTION
Fixes related to the v1.0.5.1 milestone:

"Adds a message box allowing the user to fix an issue where a partition is busy and cannot be unmounted (eg, due it being used in another application such as being the working directory of a terminal)." and fixes issue where v1.0.5 was not shipped with all video drivers because "tarting from Ubuntu 17.04 (Zesty) the 'xserver-xorg-video-all' metapackage that is used to select all open-source drivers for installation was been demoted to a recommended package of the xserver-xorg instead of a dependency".

See the kanban board and GitHub issues for more information.