### PR TITLE
Adds SMB version field, fixes domain being passed incorrectly

### DIFF
--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -1320,30 +1320,33 @@ sub mount_data {
       }
     } elsif (/SMB/) {
       # Mount a network share
-      my $args;
-      my $tmpfile = '';
-      my @smbargs = ();
-      if ($status{'mount_user'} ne '') { push(@smbargs, "username=".$status{'mount_user'}); }
-      if ($status{'mount_pass'} ne '') { push(@smbargs, "password=".$status{'mount_pass'}); }
-      if ($status{'mount_domain'} ne '') { push(@smbargs, "domain=".$status{'mount_domain'}); }
-      if ($status{'mount_version'} ne '') { push(@smbargs, "vers=".$status{'mount_version'}); }
-      my $cred = join("\n", @smbargs);
-      if ($cred eq '') { $args = "guest"; }
-      else {
-        $tmpfile = `mktemp`;
-        chomp($tmpfile);
-        open(my $tmpfd, '>', $tmpfile);
+      my $smb_args;
+
+      # Write CIFS/SMB username/password credentials to a tmp file, so it does not get logged.
+      my @smb_credential_args = ();
+      if ($status{'mount_user'} ne '') { push(@smb_credential_args, "username=".$status{'mount_user'}); }
+      if ($status{'mount_pass'} ne '') { push(@smb_credential_args, "password=".$status{'mount_pass'}); }
+      my $cred = join("\n", @smb_credential_args);
+      my $credential_tmp_file = '';
+      if ($cred eq '') {
+        $smb_args = "guest";
+      } else {
+        $credential_tmp_file = `mktemp`;
+        chomp($credential_tmp_file);
+        open(my $tmpfd, '>', $credential_tmp_file);
         print $tmpfd "$cred\n";
         close($tmpfd);
-        $args = "credentials='$tmpfile'";
-        # If the user does not supply password moutnt would try to prompt for
+        $smb_args = "credentials='$credential_tmp_file'";
+        # If the user does not supply password mount would try to prompt for
         # one locking up the application unless guest is specified.
-        if ($status{'mount_pass'} eq '') { $args = "$args,guest"; }
+        if ($status{'mount_pass'} eq '') { $smb_args = "$smb_args,guest"; }
       }
-      my $cifs_mount = "mount.cifs '$status{'mount_source'}' ".MOUNT_POINT." -o $args";
+      if ($status{'mount_domain'} ne '') { $smb_args = "$smb_args,domain=".$status{'mount_domain'}; }
+      if ($status{'mount_version'} ne '') { $smb_args = "$smb_args,vers=".$status{'mount_version'}; }
+      my $cifs_mount = "mount.cifs '$status{'mount_source'}' ".MOUNT_POINT." -o $smb_args";
       print "* ".loc("Executing: ").$cifs_mount."\n";
       system($cifs_mount);
-      if ($tmpfile ne '') { system(("shred", "-u",  $tmpfile));}
+      if ($credential_tmp_file ne '') { system(("shred", "-u",  $credential_tmp_file));}
     } elsif (/FTP/) {
       # Mount an FTP server
       my $ftpargs = '';

--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -259,6 +259,7 @@ sub backup_step {
       $status{'mount_user'} = $builder->get_object('backup_dest_user')->get_text();
       $status{'mount_pass'} = $builder->get_object('backup_dest_pass')->get_text();
       $status{'mount_domain'} = $builder->get_object('backup_dest_domain')->get_text();
+      $status{'mount_version'} = $builder->get_object('backup_dest_version')->get_text();
     }
     my $mount_ok = mount_data();
     if ($mount_ok==0) {
@@ -320,6 +321,7 @@ sub backup_dest_network_changed {
     my ($type, $server) = split(/\|/, $share);
     my $server_editable = TRUE;
     my $domain_editable = TRUE;
+    my $version_editable = TRUE;
     if ($server eq '') {
       if ($type eq 'FTP') {
         # It's a manually-entered FTP share
@@ -334,10 +336,14 @@ sub backup_dest_network_changed {
       $server =~ s/^smb:|^ftp:\/\///g;
       $server_editable = FALSE;
     }
-    if ($type ne 'SMB') { $domain_editable = FALSE; }
+    if ($type ne 'SMB') {
+      $domain_editable = FALSE;
+      $version_editable = FALSE;
+    }
     $builder->get_object('backup_dest_server')->set_text($server);
     $builder->get_object('backup_dest_server')->set_sensitive($server_editable);
     $builder->get_object('backup_dest_domain')->set_sensitive($domain_editable);
+    $builder->get_object('backup_dest_version')->set_sensitive($version_editable);
   }
 }
 
@@ -663,6 +669,7 @@ sub restore_step {
       $status{'mount_user'} = $builder->get_object('restore_source_user')->get_text();
       $status{'mount_pass'} = $builder->get_object('restore_source_pass')->get_text();
       $status{'mount_domain'} = $builder->get_object('restore_source_domain')->get_text();
+      $status{'mount_version'} = $builder->get_object('restore_source_version')->get_text();
     }
     my $mount_ok = mount_data();
     if ($mount_ok==0) {
@@ -718,6 +725,7 @@ sub restore_source_network_changed {
     my ($type, $server) = split(/\|/, $share);
     my $server_editable = TRUE;
     my $domain_editable = TRUE;
+    my $version_editable = TRUE;
     if ($server eq '') {
       if ($type eq 'FTP') {
         # It's a manually-entered FTP share
@@ -732,10 +740,14 @@ sub restore_source_network_changed {
       $server =~ s/^smb:|^ftp:\/\///g;
       $server_editable = FALSE;
     }
-    if ($type ne 'SMB') { $domain_editable = FALSE; }
+    if ($type ne 'SMB') {
+      $domain_editable = FALSE;
+      $version_editable = FALSE;
+    }
     $builder->get_object('restore_source_server')->set_text($server);
     $builder->get_object('restore_source_server')->set_sensitive($server_editable);
     $builder->get_object('restore_source_domain')->set_sensitive($domain_editable);
+    $builder->get_object('restore_source_version')->set_sensitive($version_editable);
   }
 }
 
@@ -1314,6 +1326,7 @@ sub mount_data {
       if ($status{'mount_user'} ne '') { push(@smbargs, "username=".$status{'mount_user'}); }
       if ($status{'mount_pass'} ne '') { push(@smbargs, "password=".$status{'mount_pass'}); }
       if ($status{'mount_domain'} ne '') { push(@smbargs, "domain=".$status{'mount_domain'}); }
+      if ($status{'mount_version'} ne '') { push(@smbargs, "vers=".$status{'mount_version'}); }
       my $cred = join("\n", @smbargs);
       if ($cred eq '') { $args = "guest"; }
       else {

--- a/src/livecd/chroot/usr/share/locale/de/LC_MESSAGES/rescuezilla.ko
+++ b/src/livecd/chroot/usr/share/locale/de/LC_MESSAGES/rescuezilla.ko
@@ -78,6 +78,9 @@ msgstr ""
 msgid "Domain (Optional):"
 msgstr ""
 
+msgid "Version (Optional):"
+msgstr ""
+
 msgid "Select network-shared storage destination:"
 msgstr ""
 

--- a/src/livecd/chroot/usr/share/locale/es/LC_MESSAGES/rescuezilla.ko
+++ b/src/livecd/chroot/usr/share/locale/es/LC_MESSAGES/rescuezilla.ko
@@ -78,6 +78,9 @@ msgstr "Contraseña (Opcional):"
 msgid "Domain (Optional):"
 msgstr "Dominio (Opcional):"
 
+msgid "Version (Optional):"
+msgstr ""
+
 msgid "Select network-shared storage destination:"
 msgstr "Seleccione el destino de almacenamiento compartido en red:"
 

--- a/src/livecd/chroot/usr/share/locale/fr/LC_MESSAGES/rescuezilla.ko
+++ b/src/livecd/chroot/usr/share/locale/fr/LC_MESSAGES/rescuezilla.ko
@@ -79,6 +79,9 @@ msgstr "Mot de passe : (optionnel):"
 msgid "Domain (Optional):"
 msgstr "Domaine : (optionnel):"
 
+msgid "Version (Optional):"
+msgstr ""
+
 msgid "Select network-shared storage destination:"
 msgstr "Sélectionnez le partage réseau de destination :"
 

--- a/src/livecd/chroot/usr/share/rescuezilla/rescuezilla.glade
+++ b/src/livecd/chroot/usr/share/rescuezilla/rescuezilla.glade
@@ -504,7 +504,7 @@
                                                             <child>
                                                             <object class="GtkTable" id="backup_dest_entries1">
                                                             <property name="visible">True</property>
-                                                            <property name="n_rows">4</property>
+                                                            <property name="n_rows">5</property>
                                                             <property name="n_columns">2</property>
                                                             <property name="column_spacing">5</property>
                                                             <property name="row_spacing">5</property>
@@ -603,6 +603,31 @@
                                                             <property name="right_attach">2</property>
                                                             <property name="top_attach">3</property>
                                                             <property name="bottom_attach">4</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkLabel" id="backup_dest_version_label1">
+                                                            <property name="visible">True</property>
+                                                            <property name="xalign">1</property>
+                                                            <property name="label" translatable="yes">Version (Optional):</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="top_attach">5</property>
+                                                            <property name="bottom_attach">6</property>
+                                                            <property name="x_options">GTK_FILL</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkEntry" id="backup_dest_version">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">True</property>
+                                                            <property name="invisible_char">●</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left_attach">1</property>
+                                                            <property name="right_attach">2</property>
+                                                            <property name="top_attach">5</property>
+                                                            <property name="bottom_attach">6</property>
                                                             </packing>
                                                             </child>
                                                             </object>
@@ -1135,7 +1160,7 @@ You may only use letters, numbers, and dashes in your backup name.</property>
                                                             <child>
                                                             <object class="GtkTable" id="restore_source_entries">
                                                             <property name="visible">True</property>
-                                                            <property name="n_rows">4</property>
+                                                            <property name="n_rows">5</property>
                                                             <property name="n_columns">2</property>
                                                             <property name="column_spacing">5</property>
                                                             <property name="row_spacing">5</property>
@@ -1234,6 +1259,31 @@ You may only use letters, numbers, and dashes in your backup name.</property>
                                                             <property name="right_attach">2</property>
                                                             <property name="top_attach">3</property>
                                                             <property name="bottom_attach">4</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkLabel" id="restore_source_version_label">
+                                                            <property name="visible">True</property>
+                                                            <property name="xalign">1</property>
+                                                            <property name="label" translatable="yes">Version (Optional):</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="top_attach">5</property>
+                                                            <property name="bottom_attach">6</property>
+                                                            <property name="x_options">GTK_FILL</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkEntry" id="restore_source_version">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">True</property>
+                                                            <property name="invisible_char">●</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left_attach">1</property>
+                                                            <property name="right_attach">2</property>
+                                                            <property name="top_attach">5</property>
+                                                            <property name="bottom_attach">6</property>
                                                             </packing>
                                                             </child>
                                                             </object>


### PR DESCRIPTION
Fixes Rescuezilla v1.0.5 not having a way to specify the SMB version and connect to old SMB servers, such as those on Ubuntu 12.04.

Also fixes the domain field not correctly being passed via the mount.cifs command.