### PR TITLE
Remove accidental unmount of source partition

### DIFF
--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -1407,7 +1407,6 @@ sub umount_warn_on_busy {
   my $mount_point = $_[0];
   # Keep looping until the busy partition list is empty
   my @busy_device_node_list = umount_partition("$mount_point");
-  print "The length of the busy partition is ".scalar(@busy_device_node_list)." \n";
   while (scalar(@busy_device_node_list) != 0) {
     my $partition_pretty_string = "";
     foreach my $device_node (@busy_device_node_list) {

--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -904,7 +904,6 @@ sub update_restore_progress {
   # See if the filehandle is open
   if (!defined($PROGRESS)) {
     umount_warn_on_busy("/dev/$dest_drive$pn");
-    umount_warn_on_busy("/dev/$part");
     system("dd if=/dev/zero of=/dev/$dest_drive$pn bs=1K count=1000; sync");
     set_status(loc("Preparing to restore backup for Drive [_1], Part [_2]...",$dn,$pn));
     my $backup_version = `cat /$src.rescuezilla.backup_version`;


### PR DESCRIPTION
A recent commit added a retry msg box to unmount busy partitions. During a restore operation, unmounting the source partition was added and the commit tested without issue. However, the source partition variable during a restore operation contains the original device node used during the backup operation, which may have been on a different computer. Thus this device node has no bearing on the restore operation, and it may even happen to be the device node that holds the backup files being restored (causing the restore to fail). This partition should therefore not be unmounted.