### PR TITLE
Adds support for backup/restore of NVMe drives

### DIFF
--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -360,9 +360,9 @@ sub do_backup {
   $dest =~ s/\/$//;
   $dest =~ s/ /\\ /g;
   my $file = $builder->get_object('backup_name')->get_text();
-  my $src_drive = $src;
-  $src_drive =~ s/\d//g;
-  $src_drive = "/dev/".$src_drive;
+  my $enduser_drive_number = get_enduser_drive_number($src);
+  my ($base_device, $partition_number) = split_device_string($src);
+  my $src_drive = "/dev/$base_device";
   # Save MBR
   system("dd if=$src_drive of=$dest/$file.mbr bs=32768 count=1");
   system("sfdisk -d $src_drive > $dest/$file.sfdisk");
@@ -388,10 +388,9 @@ sub do_backup {
   #print Dumper(%drives);
   my $total_bytes = 0;
   foreach my $part (@partlist) {
-    my ($dn, $pn) = get_drivenum_partnum($part);
-    my $dev = $src_drive;
-    $dev =~ s/^\/dev\///g;
-    my $part_bytes = $drives{$dev}{'parts'}{$pn}{'bytes'};
+    my $enduser_drive_number = get_enduser_drive_number($part);
+    my ($base_device, $partition_number) = split_device_string($part);
+    my $part_bytes = $drives{$base_device}{'parts'}{$partition_number}{'bytes'};
     $total_bytes += $part_bytes;
   }
   $status{'start'} = time();
@@ -421,13 +420,14 @@ sub update_backup_progress {
   my $data = undef;
   our $i;
   my $part = $status{'part_list'}[$status{'current_part'}];
-  my ($dn, $pn) = get_drivenum_partnum($part);
+  my $enduser_drive_number = get_enduser_drive_number($part);
+  my ($base_device, $partition_number) = split_device_string($part);
   my $src = $status{'backup_drive'};
   my $dest = MOUNT_POINT.$builder->get_object('backup_folder')->get_text();
   $dest =~ s/\/$//;
   $dest =~ s/ /\\ /g;
   my $file = $builder->get_object('backup_name')->get_text();
-  my $fs = lc($drives{$src}{'parts'}{$pn}{'fstype'});
+  my $fs = lc($drives{$src}{'parts'}{$partition_number}{'fstype'});
   # Write the Rescuezilla version to a file to help future versions best handle future backwards-compatibility
   my $version = VERSION;
   chomp($version);
@@ -441,12 +441,12 @@ sub update_backup_progress {
     my $tool_missing_msg = loc("The tool [_1] does not exist", "/usr/sbin/$tool");
     fatal_crash($tool_missing_msg) unless -e "/usr/sbin/$tool";
     # Write the exact partclone command used to create the backup of the current partition. This tool is required during restore.
-    system("echo $tool > $dest/$file.partclone.command.part$pn");
-    set_status(loc("Preparing to create backup of Drive [_1], Part [_2]...",$dn, $pn));
+    system("echo $tool > $dest/$file.partclone.command.part$partition_number");
+    set_status(loc("Preparing to create backup of Drive [_1], Part [_2]...",$enduser_drive_number, $partition_number));
     print "*** ".loc("Processing [_1] ([_2]) using [_3]...",$part,$fs,$tool)."\n";
     umount_warn_on_busy("/dev/$part");
 
-    my $backup_cmd = "( $tool $extra_args -F -L /$dest/$file"."_part$pn"."_partclone.log -s /dev/$part | pigz -c --fast | split -d -a 3 -b 2048m - /$dest/$file"."_part$pn. ) 2>&1 |";
+    my $backup_cmd = "( $tool $extra_args -F -L /$dest/$file"."_part$partition_number"."_partclone.log -s /dev/$part | pigz -c --fast | split -d -a 3 -b 2048m - /$dest/$file"."_part$partition_number. ) 2>&1 |";
     print "*** ".loc("Executing: ")."$backup_cmd\n";
     open $PROGRESS, "$backup_cmd";
     sleep(0.5);
@@ -506,11 +506,11 @@ sub update_backup_progress {
     } elsif ($data =~ m/Reading Super Block/) {
       # Reading super block
       print(">>> ".loc("Reading super block")."\n");
-      set_status(loc("Reading super block for Drive [_1], Part [_2]...",$dn,$pn));
+      set_status(loc("Reading super block for Drive [_1], Part [_2]...",$enduser_drive_number,$partition_number));
     } elsif ($data =~ m/Calculating bitmap/) {
       # Calculating bitmap
       print(">>> ".loc("Calculating bitmap")."\n");
-      set_status(loc("Calculating bitmap for Drive [_1], Part [_2]...",$dn,$pn));
+      set_status(loc("Calculating bitmap for Drive [_1], Part [_2]...",$enduser_drive_number,$partition_number));
     } elsif ($data =~ m/Elapsed.+\%$/) {
       # Calculating bitmap, percentage given
       #Elapsed: 00:00:03, Remaining: 00:00:00, Completed:  93.41%
@@ -521,7 +521,7 @@ sub update_backup_progress {
       $msg = loc("Reading bitmap for part [_1] of [_2]",$status{'current_part'}+1,$status{'total_parts'});
       $builder->get_object('backup_progress_status')->set_text($msg);
       print ">>> ".loc("Calculating bitmap progress: [_1]% Remaining: [_2]",$pct,$remaining)."\n";
-      set_status(loc("Reading bitmap for Drive [_1], Part [_2] ([_3]% done, [_4] remaining)",$dn,$pn,$pct,$remaining));
+      set_status(loc("Reading bitmap for Drive [_1], Part [_2] ([_3]% done, [_4] remaining)",$enduser_drive_number,$partition_number,$pct,$remaining));
     } elsif ($data =~ m/Elapsed.+,$/) {
       # Backup progress line
       $status{'frame'}++;
@@ -539,11 +539,11 @@ sub update_backup_progress {
       $msg = loc("Part [_1] of [_2] ([_3]%)\n[_4] Elapsed\n[_5] Remaining",$status{'current_part'}+1, $status{'total_parts'},$pct,$elapsed,$remaining);
       $builder->get_object('backup_progress_status')->set_text($msg);
       # Base overall percentage on number of total bytes
-      my $current_bytes = int(($pct/100) * $drives{$src}{'parts'}{$pn}{'bytes'}) + $status{'done_bytes'};
+      my $current_bytes = int(($pct/100) * $drives{$src}{'parts'}{$partition_number}{'bytes'}) + $status{'done_bytes'};
       my $overall_pct = ($current_bytes / $status{'total_bytes'}) + (($pct / 100) / $status{'total_bytes'});
       if ($overall_pct > 1) { $overall_pct = 1; }
-      set_status(loc("Saving part [_1] ([_2]) at [_3] ([_4] free space)", $status{'current_part'}+1, $drives{$src}{'parts'}{$pn}{'size'},$rate,$status{'free'}));
-      print ">>> ".loc("Drive: [_1] | Partition: [_2] | Current bytes: [_3] | Overall: [_4]",$src,$pn,$current_bytes,$overall_pct)."\n";
+      set_status(loc("Saving part [_1] ([_2]) at [_3] ([_4] free space)", $status{'current_part'}+1, $drives{$src}{'parts'}{$partition_number}{'size'},$rate,$status{'free'}));
+      print ">>> ".loc("Drive: [_1] | Partition: [_2] | Current bytes: [_3] | Overall: [_4]",$src,$partition_number,$current_bytes,$overall_pct)."\n";
       $progress_bar->set_fraction($overall_pct);
       $msg = loc("[_1]% Complete", sprintf("%.2f", $overall_pct * 100));
       $progress_bar->set_text($msg);
@@ -575,7 +575,7 @@ sub update_backup_progress {
         close $PROGRESS;
         undef($PROGRESS);
         # Need to add the size of the partition to the total bytes completed
-        $status{'done_bytes'} += $drives{$src}{'parts'}{$pn}{'bytes'};
+        $status{'done_bytes'} += $drives{$src}{'parts'}{$partition_number}{'bytes'};
         print ">>> Backed up ".$status{'done_bytes'}." of ".$status{'total_bytes'}." total bytes.\n";
         $status{'current_part'}++;
         print ">>> Advancing to next partition.\n";
@@ -860,22 +860,25 @@ sub do_restore {
   # Verify all partitions now exist; crash otherwise
   foreach my $part (@{$status{'part_list'}}) {
     chomp($part);
-    my ($dn, $pn) = get_drivenum_partnum($part);
-    my $pid = $dest_drive.$pn;
-    print "*** ".loc("Verifying that /dev/[_1] exists and can be restored to: ",$pid);
-    my $part_check = `file /dev/$pid | grep 'block special' | wc -l`;
+    my ($src_base_device, $src_partition_number) = split_device_string($part);
+    my $dest_partition_node = join_device_string($dest_drive, $src_partition_number);
+    # FIXME: Update this misleading comment (including localizations if possible)
+    print "*** ".loc("Verifying that /dev/[_1] exists and can be restored to: ",$dest_partition_node);
+    my $part_check = `file /dev/$dest_partition_node | grep 'block special' | wc -l`;
     if ($part_check==1) {
       print loc("OK")."\n";
     } else {
       print loc("FAIL")."\n";
       fatal_crash(loc("The partition table did not restore properly. The backup image may contain all your data, but without a valid partition table, no data can be restored."));
     }
-    my $bytes = `cat /sys/block/$dest_drive/$dest_drive$pn/size`;
+    my $bytes = `cat /sys/block/$dest_drive/$dest_partition_node/size`;
     chomp($bytes);
     $bytes = abs(int($bytes*512));
-    print "*** ".loc("Device [_1][_2] is [_3] bytes...",$dest_drive,$pn,$bytes)."\n";
-    $drives{$dest_drive}{'parts'}{$pn}{'bytes'} = $bytes;
-    $drives{$dest_drive}{'parts'}{$pn}{'size'} = format_size($bytes);
+    print "*** ".loc("Device [_1] is [_2] bytes...",$dest_partition_node,$bytes)."\n";
+    # TODO: Indexing by source partition number (not dest). This is acceptable within current limitations
+    # TODO: (immature partition-to-partition backup), but should be rectified in future.
+    $drives{$dest_drive}{'parts'}{$src_partition_number}{'bytes'} = $bytes;
+    $drives{$dest_drive}{'parts'}{$src_partition_number}{'size'} = format_size($bytes);
     $status{'total_bytes'} += $bytes;
   }
   $status{'done_bytes'} = 0;
@@ -895,17 +898,20 @@ sub update_restore_progress {
   our $i;
   my $part = $status{'part_list'}[$status{'current_part'}];
   chomp($part);
-  my ($dn, $pn) = get_drivenum_partnum($part); 
   my $src = $builder->get_object('restore_file')->get_filename();
+  my $enduser_drive_string = $src;
+  my ($base_device, $partition_number) = split_device_string($part);
   my $dest_drive = $builder->get_object('restore_dest')->get_active_text();
+  # Combine the target drive with the current partition number in an NVMe-aware manner.
+  my $dest_partition_node = join_device_string($dest_drive, $partition_number);
   $src =~ s/\.backup$//g;
   $src =~ s/ /\\ /g;
   my $src_mbr = $src.'.mbr';
   # See if the filehandle is open
   if (!defined($PROGRESS)) {
-    umount_warn_on_busy("/dev/$dest_drive$pn");
-    system("dd if=/dev/zero of=/dev/$dest_drive$pn bs=1K count=1000; sync");
-    set_status(loc("Preparing to restore backup for Drive [_1], Part [_2]...",$dn,$pn));
+    umount_warn_on_busy("/dev/$dest_partition_node");
+    system("dd if=/dev/zero of=/dev/$dest_partition_node bs=1K count=1000; sync");
+    set_status(loc("Preparing to restore backup for Drive [_1], Part [_2]...",$enduser_drive_string,$partition_number));
     my $backup_version = `cat /$src.rescuezilla.backup_version`;
     chomp($backup_version);
     print loc("Detected backup created with [_1]",$backup_version)."\n";
@@ -916,19 +922,19 @@ sub update_restore_progress {
         # The Redo Backup v1.0.4 partclone version uses different restore syntax, and autodetects raw formats differently
         print loc("Using partclone [_1] to restore the [_2] backup, for maximum compatibility",$partclone_ver,"Redo Backup and Recovery v1.0.4")."\n";
         my $tool = "partclone.restore.$partclone_ver";
-        print "*** ".loc("Processing [_1] using [_2]...","$dest_drive$pn",$tool)."\n";
-        $restore_cmd = "( cat /$src"."_part$pn.* | pigz -d -c | $tool -F -L /partclone.log -O /dev/$dest_drive$pn ) 2>&1 |";
+        print "*** ".loc("Processing [_1] using [_2]...","$dest_partition_node",$tool)."\n";
+        $restore_cmd = "( cat /$src"."_part$partition_number.* | pigz -d -c | $tool -F -L /partclone.log -O /dev/$dest_partition_node ) 2>&1 |";
     } else {
         # Assume backup was created with a format compatible with the 1.0.5 release.
         # TODO: Compare the MAJOR.MINOR.PATCH components that make up the version number to automatically handle newer versions
         # TODO: when the backup format and partclone syntax have not changed.
         print loc("Restoring backup created with version: [_1]",$backup_version)."\n";
-        my $tool = `cat $src.partclone.command.part$pn`;
+        my $tool = `cat $src.partclone.command.part$partition_number`;
         chomp($tool);
         my $tool_missing_msg = loc("The tool [_1] does not exist", "/usr/sbin/$tool");
         fatal_crash($tool_missing_msg) unless -e "/usr/sbin/$tool";
-        print "*** ".loc("Processing [_1] using [_2]...","$dest_drive$pn",$tool)."\n";
-        $restore_cmd = "( cat /$src"."_part$pn.* | pigz -d -c | $tool --restore -F -L /partclone.log -O /dev/$dest_drive$pn ) 2>&1 |";
+        print "*** ".loc("Processing [_1] using [_2]...","$dest_partition_node",$tool)."\n";
+        $restore_cmd = "( cat /$src"."_part$partition_number.* | pigz -d -c | $tool --restore -F -L /partclone.log -O /dev/$dest_partition_node ) 2>&1 |";
     }
     print "*** ".loc("Executing: ")."$restore_cmd\n";
     open $PROGRESS, "$restore_cmd";
@@ -989,11 +995,11 @@ sub update_restore_progress {
     } elsif ($data =~ m/Reading Super Block/) {
       # Reading super block
       print(">>> ".loc("Reading super block:")."\n");
-      set_status(loc("Reading super block for Drive [_1], Part [_2]...",$dn,$pn));
+      set_status(loc("Reading super block for Drive [_1], Part [_2]...",$enduser_drive_string,$partition_number));
     } elsif ($data =~ m/Calculating bitmap/) {
       # Reading super block
       print(">>> ".loc("Calculating bitmap")."\n");
-      set_status(loc("Calculating bitmap for Drive [_1], Part [_2]...",$dn,$pn));
+      set_status(loc("Calculating bitmap for Drive [_1], Part [_2]...",$enduser_drive_string,$partition_number));
     } elsif ($data =~ m/Elapsed.+,$/) {
       # Restore progress line
       my $elapsed = substr($data,9,8);
@@ -1006,11 +1012,11 @@ sub update_restore_progress {
       $msg = loc("Part [_1] of [_2] ([_3]%)\n[_4] Elapsed\n[_5] Remaining",$status{'current_part'}+1,$status{'total_parts'},$pct,$elapsed,$remaining);
       $builder->get_object('restore_progress_status')->set_text($msg);
       # Base overall percentage on number of total bytes
-      my $current_bytes = int(($pct/100) * $drives{$dest_drive}{'parts'}{$pn}{'bytes'}) + $status{'done_bytes'};
+      my $current_bytes = int(($pct/100) * $drives{$dest_drive}{'parts'}{$partition_number}{'bytes'}) + $status{'done_bytes'};
       my $overall_pct = ($current_bytes / $status{'total_bytes'}) + (($pct / 100) / $status{'total_bytes'});
       if ($overall_pct > 1) { $overall_pct = 1; }
-      set_status(loc("Restoring part [_1] ([_2]) at [_3]",$status{'current_part'}+1,$drives{$dest_drive}{'parts'}{$pn}{'size'},$rate));
-      print ">>> ".loc("Drive: [_1] | Partition: [_2] | Current bytes: [_3] | Overall: [_4]",$src,$pn,$current_bytes,$overall_pct)."\n";
+      set_status(loc("Restoring part [_1] ([_2]) at [_3]",$status{'current_part'}+1,$drives{$dest_drive}{'parts'}{$partition_number}{'size'},$rate));
+      print ">>> ".loc("Drive: [_1] | Partition: [_2] | Current bytes: [_3] | Overall: [_4]",$src,$partition_number,$current_bytes,$overall_pct)."\n";
       $progress_bar->set_fraction($overall_pct);
       $msg = loc("[_1]% Complete", sprintf("%.2f", $overall_pct * 100));
       $progress_bar->set_text($msg);
@@ -1024,7 +1030,7 @@ sub update_restore_progress {
       print ">>> ".loc("(BITMAP) Elapsed: *[_1]* | Remaining: *[_2]* | Percent: *[_3]*",$elapsed,$remaining,$pct)."\n";
       $msg = loc("Reading bitmap for part [_1] of [_2]",$status{'current_part'}+1,$status{'total_parts'});
       $builder->get_object('restore_progress_status')->set_text($msg);
-      set_status(loc("Reading bitmap for Drive [_1], Part [_2] ([_3]% done, [_4] remaining)",$dn,$pn,$pct,$remaining));
+      set_status(loc("Reading bitmap for Drive [_1], Part [_2] ([_3]% done, [_4] remaining)",$enduser_drive_string,$partition_number,$pct,$remaining));
     } elsif ($data =~ m/Cloned successfully/) {
       set_status(loc("Partition completed."));
       print ">>> ".loc("Partition [_1] completed.",$status{'current_part_device'})."\n";
@@ -1058,7 +1064,7 @@ sub update_restore_progress {
         close $PROGRESS;
         undef($PROGRESS);
         # Need to add the size of the partition to the total bytes completed
-        $status{'done_bytes'} += $drives{$dest_drive}{'parts'}{$pn}{'bytes'};
+        $status{'done_bytes'} += $drives{$dest_drive}{'parts'}{$partition_number}{'bytes'};
         print ">>> ".loc("Backed up [_1] of [_2] total bytes.",$status{'done_bytes'},$status{'total_bytes'})."\n";
         $status{'current_part'}++;
         print loc("Advancing to next partition.")."\n";
@@ -1443,7 +1449,9 @@ sub set_drive_dropdown {
   my $mdl = $cbo->get_model();
   $mdl->clear();
   my ($dev, $desc) = '';
-  for my $drive (sort keys %drives) {
+  # Iterate over the drives hashmap using the generated drive number (rather than the device node), by
+  # retrieving a numerical ordered array of the hashmap's keys.
+  foreach my $drive (sort { $drives{$a}{'enduser_drive_number'} <=> $drives{$b}{'enduser_drive_number'} } keys %drives) {
     $dev = $drives{$drive}{'device'};
     $desc = $drives{$drive}{'desc'};
     if (length($desc)>MAX_WIDTH+3) { $desc = substr($desc,0,MAX_WIDTH).'...'; }
@@ -1478,19 +1486,22 @@ sub set_partition_dropdown {
   my $cbo = our $builder->get_object($_[0]);
   my $mdl = $cbo->get_model();
   $mdl->clear();
-  for my $drive (sort keys %drives) {
-    for my $data (sort keys %{ $drives{$drive}{'parts'} }) {
+  # Iterate over the drives hashmap using the generated drive number (rather than the device node), by
+  # retrieving a numerical ordered array of the hashmap's keys.
+  foreach my $drive (sort { $drives{$a}{'enduser_drive_number'} <=> $drives{$b}{'enduser_drive_number'} } keys %drives) {
+    # Iterate over the partitions of a particular drive by sorting the partition number using numerical (not lexical) ordering.
+    foreach my $data (sort {$drives{$drive}{'parts'}{$a}{'partition_number'} <=> $drives{$drive}{'parts'}{$b}{'partition_number'}} keys %{ $drives{$drive}{'parts'} }) {
       my $num_parts = keys(%{ $drives{$drive}{'parts'} });
-      my $dn = $drives{$drive}{'drivenum'};
-      my $pn = $data;
+      my $enduser_drive_number = $drives{$drive}{'enduser_drive_number'};
       my $part = $drives{$drive}{'parts'}{$data}{'partition'};
+      my $partition_number = $drives{$drive}{'parts'}{$data}{'partition_number'};
       my $fs = $drives{$drive}{'parts'}{$data}{'fstype'};
       my $label = $drives{$drive}{'parts'}{$data}{'label'};
       my $size = $drives{$drive}{'parts'}{$data}{'size'};
       if (!defined($size)) { $size = "Unknown size"; }
       my $os = $drives{$drive}{'parts'}{$data}{'os'};
-      my $part_desc =  loc("Drive [_1]",$dn);
-      if ($num_parts > 1) { $part_desc .= loc(", Part [_1]",$pn); }
+      my $part_desc =  loc("Drive [_1]",$enduser_drive_number);
+      if ($num_parts > 1) { $part_desc .= loc(", Part [_1]",$partition_number); }
       $part_desc .= ": ($size $fs)";
       if ($os ne '') { $part_desc .= " $os"; }
       if ($label ne '') { $part_desc .= " $label"; }
@@ -1570,9 +1581,9 @@ sub set_partition_list {
   for my $drive (sort keys %drives) {
     for my $data (sort keys %{ $drives{$drive}{'parts'} }) {
       my $num_parts = keys(%{ $drives{$drive}{'parts'} });
-      my $dn = $drives{$drive}{'drivenum'};
-      my $pn = $data;
+      my $enduser_drive_number = $drives{$drive}{'enduser_drive_number'};
       my $part = $drives{$drive}{'parts'}{$data}{'partition'};
+      my $partition_number = $drives{$drive}{'parts'}{$data}{'partition_number'};
       my $fs = $drives{$drive}{'parts'}{$data}{'fstype'};
       my $label = $drives{$drive}{'parts'}{$data}{'label'};
       my $size = $drives{$drive}{'parts'}{$data}{'size'};
@@ -1581,7 +1592,7 @@ sub set_partition_list {
       # FIXME: Unclear why this l10n string lookup doesn't work with this string,
       # FIXME: but works with other strings.
       # FIXME: May be bug with maketext deduplication?
-      my $part_desc = loc("Drive [_1], Part [_2]",$dn,$pn);
+      my $part_desc = loc("Drive [_1], Part [_2]",$enduser_drive_number,$partition_number);
       $part_desc .= ": ($size $fs)";
       if ($os ne '') { $part_desc .= " $os"; }
       if ($label ne '') { $part_desc .= ", $label"; }
@@ -1602,10 +1613,10 @@ sub print_drive_list {
     for my $drive_key (sort keys %{ $drives{$dev} }) {
       print "\t$drive_key = $drives{$dev}{$drive_key}\n";
       if(ref($drives{$dev}{$drive_key}) eq 'HASH') {
-        for my $pn (sort keys %{ $drives{$dev}{$drive_key} }) {
-          print "\t".loc("Part [_1]",$pn).":\n";
-          for my $pk (sort keys %{ $drives{$dev}{$drive_key}{$pn} }) {
-            print "\t\t$pk = $drives{$dev}{$drive_key}{$pn}{$pk}\n"; 
+        for my $partition_number (sort keys %{ $drives{$dev}{$drive_key} }) {
+          print "\t".loc("Part [_1]",$partition_number).":\n";
+          for my $pk (sort keys %{ $drives{$dev}{$drive_key}{$partition_number} }) {
+            print "\t\t$pk = $drives{$dev}{$drive_key}{$partition_number}{$pk}\n";
           }
         }
       }
@@ -1652,18 +1663,19 @@ sub find_local_drives {
       $size =~ s/^\s*//g;
       $size =~ s/\s+//g;
       if (!defined($size)) { $size = 'Unknown'; }
-      my ($drivenum) = get_drivenum_partnum($dev);
+      my $enduser_drive_number = get_enduser_drive_number($dev);
+      my ($base_device, $partition_number) = split_device_string($dev);
       my $type = get_drivetype($dev);
-      my $desc = loc("Drive [_1] ([_2]): [_3]",$drivenum,$size,$dev_name);
-      if ($type eq 'usb') { $desc = loc("Drive [_1] ([_2]): USB [_3]",$drivenum,$size,$dev_name); }
+      my $desc = loc("Drive [_1] ([_2]): [_3]",$enduser_drive_number,$size,$dev_name);
+      if ($type eq 'usb') { $desc = loc("Drive [_1] ([_2]): USB [_3]",$enduser_drive_number,$size,$dev_name); }
       $drives{$dev} = {
-        'device'        => $dev,
-        'drivenum'      => $drivenum,
-        'size'          => $size,
-        'model'         => $dev_name,
-        'type'          => $type,
-        'desc'          => $desc,
-        'parts'         => {},
+        'device'               => $dev,
+        'enduser_drive_number' => $enduser_drive_number,
+        'size'                 => $size,
+        'model'                => $dev_name,
+        'type'                 => $type,
+        'desc'                 => $desc,
+        'parts'                => {},
       };
     }
   }
@@ -1673,7 +1685,7 @@ sub find_local_drives {
 }
 
 sub find_local_partitions {
-  # Set the list of local partitions for SCSI and USB drives
+  # Set the list of local partitions for SCSI, USB and NVMe drives
   our %drives;
   set_busy(loc("Identifying disk drives..."));
   my $partlist = `fsarchiver probe 2>&1`;
@@ -1700,14 +1712,14 @@ sub find_local_partitions {
       $label = '' if $label eq '<unknown>';
       $size = trim($size);
       $size =~ s/\s+//g;
-      my $dev = $partition;
-      $dev =~ s/\d//g;
-      my ($dn, $pn) = get_drivenum_partnum($partition);
-      my $bytes = `cat /sys/block/$dev/$dev$pn/size`;
+      my $enduser_drive_number = get_enduser_drive_number($partition);
+      my ($dev, $partition_number) = split_device_string($partition);
+      my $bytes = `cat /sys/block/$dev/$partition/size`;
       chomp($bytes);
       $bytes = abs(int($bytes*512));
       my $part = {
         'partition' => $partition,
+        'partition_number' => $partition_number,
         'fstype'    => $fstype,
         'label'     => $label,
         'size'      => $size,
@@ -1715,7 +1727,7 @@ sub find_local_partitions {
         'os'        => '',
       };
       # Save the details in a final list
-      $drives{$dev}{'parts'}{$pn} = $part;
+      $drives{$dev}{'parts'}{$partition_number} = $part;
     }
     # Identify any operating systems
     refresh_window();
@@ -1726,10 +1738,11 @@ sub find_local_partitions {
       foreach my $line (@list) {
         my ($os_part, $os_name, $os_type, $os_loader) = split(/:/, $line);
         my $dev = $os_part;
-        my ($dn, $pn) = get_drivenum_partnum($os_part);
+        my $enduser_drive_number = get_enduser_drive_number($os_part);
+        my ($base_device, $partition_number) = split_device_string($os_part);
         $dev =~ s/\d|\/dev\///g;
         if ($os_name ne '') {
-          $drives{$dev}{'parts'}{$pn}{'os'} = $os_name;
+          $drives{$dev}{'parts'}{$partition_number}{'os'} = $os_name;
         }
       }
     }
@@ -1737,12 +1750,12 @@ sub find_local_partitions {
   # Update the drive description to include labels and OS types
   for my $dev (sort keys %drives) {
     if(ref($drives{$dev}{'parts'}) eq 'HASH') {
-      for my $pn (sort keys %{ $drives{$dev}{'parts'} }) {
+      for my $partition_number (sort keys %{ $drives{$dev}{'parts'} }) {
         my $desc = ' ';
-        my $label = $drives{$dev}{'parts'}{$pn}{'label'};
-        my $os = $drives{$dev}{'parts'}{$pn}{'os'};
-        my $size = $drives{$dev}{'parts'}{$pn}{'size'};
-        my $fstype = $drives{$dev}{'parts'}{$pn}{'fstype'};
+        my $label = $drives{$dev}{'parts'}{$partition_number}{'label'};
+        my $os = $drives{$dev}{'parts'}{$partition_number}{'os'};
+        my $size = $drives{$dev}{'parts'}{$partition_number}{'size'};
+        my $fstype = $drives{$dev}{'parts'}{$partition_number}{'fstype'};
         if ($os ne '') {
           $desc .= "($os, $size $fstype)";
         } else {
@@ -1841,14 +1854,128 @@ sub scan_network {
   set_share_dropdown($_[0]);
 }
 
-sub get_drivenum_partnum {
-  # Given a /dev/XXX partition, return the drive and partition numbers
-  my $dpd = $_[0];
-  $dpd =~ s/\/dev\/sd|sd//g;
-  my $dn = substr($dpd,0,1);
-  $dn = ord("\L$dn")-96;
-  my $pn = substr($dpd,1);
-  return ($dn, $pn);
+sub get_enduser_drive_number {
+  # For a given partition, query the devices in the kernel and return a drive number that can be associated with
+  # the partition's base device.
+  #
+  # Warning: insertion of new devices (eg, inserting USB drive /dev/sdc) may change the drive number of existing
+  # drives, so this integer must ONLY BE USED FOR DISPLAY PURPOSES (NOT in backup/restore operations)
+  #
+  # Input arguments:
+  #   input_partition: the partition device node. Eg, 'sda5' or 'nvme0n1p3'
+  #                    The base device node associated with this partition (eg sda or nvme0n1) MUST exist on the
+  #                    current system, as the kernel state is queried (via lsblk)
+  # 
+  # Returns:
+  #   * Human-readable drive number (-1 on error)
+  #         For display to the target end-user (who may find UNIX device strings unfamiliar and intimidating.
+  my $input_partition = $_[0];
+
+  # List block devices, and extract the "internal parent kernel device name", ie the base device node.
+  my $base_device = `lsblk --noheadings --output=pkname --nodeps /dev/$input_partition`;
+  my $lsblk_exit_code = $?;
+  if ($lsblk_exit_code == 0) {
+    # The list block returned success.
+    chomp($base_device);
+    # If "internal parent kernel device name" field is empty, we assume input was already the base device.
+    if (("$base_device" cmp "") == 0) {
+      $base_device = $input_partition;
+    }
+  } elsif ($lsblk_exit_code == 1) {
+    print "lsblk reported error.\n";
+    return -1;
+  } elsif ($lsblk_exit_code == 32) {
+    print "lsblk reported none of the specified partitions found for /dev/$input_partition\n";
+    return -1;
+  } elsif ($lsblk_exit_code == 64) {
+    print "lsblk reported only some of the specified partitions found for /dev/$input_partition\n";
+    return -1;
+  } else {
+    print "lsblk encountered unexpected error.\n";
+    return -1;
+  }
+
+  # Calculate human-readable drive number from the output of lsblk 
+  my $enduser_drive_number = -1;
+  # Array containing all the base device strings
+  my @all_base_devices = split /\n/, `lsblk --noheadings --output=name --nodeps`;
+  # Drive number for enduser display starting from 1, rather than 0;
+  my $index = 1;
+  foreach my $candidate_base_device (@all_base_devices) {
+    if ($candidate_base_device =~ /$base_device/) {
+      $enduser_drive_number = $index;
+    }
+    $index++;
+  }
+  if ($enduser_drive_number == -1) {
+    print "Could not find $base_device string in: @all_base_devices\n";
+    return -1;
+  }
+
+  return $enduser_drive_number;
+}
+
+sub split_device_string {
+  # For a given partition, use regular expressions to return the UNIX base device node string,
+  # and the partition number.
+  #
+  # Input arguments:
+  #   input_partition: A partition device string. Eg, 'sda5', 'nvme0n1p3'.
+  #                    For the purposes of this function the partition device node (eg, '/dev/sda5' or '/dev/nvme0n1p3'),
+  #                    and its base device node (eg, '/dev/sda' or '/dev/nvme0n1') do NOT need to be present.
+  #                    Note: Do NOT pass input with regex characters (like forward slash or asterisk wildcards).
+  #
+  # Returns:
+  #   List in the form (sda, 5) or (nvme0n1, 3), which contains:
+  #     * The base device node
+  #     * Partition number (eg. 5 from "sda5" or 3 from "nvme0n1p3")
+  my $input_partition = $_[0];
+
+  # Get the partition number by removing everything from the start of the line until the final alphabetical letter.
+  # Eg, get the '5' from sda5 or the '3' from nvme0n1p3.
+  my $partition_number = $input_partition;
+  $partition_number =~ s/.*[a-zA-Z]//;
+  if ($partition_number eq "") {
+    print "Input partition $input_partition could not be parsed.\n";
+  } else {
+    $partition_number = int($partition_number);
+  }
+
+  my $base_device = $input_partition;
+  # Get the base device using a regex pattern (the contents of the parenthesis is returned, ie a regex capturing group)
+  if ($base_device =~ /nvme.*/) {
+    # From nvme0n1p3, delete everything after the 'p', including the 'p'
+    $base_device =~ s/p.*//;
+  } else {
+    # Delete all numeric characters.
+    $base_device =~ s/[0-9]+.*//;
+  }
+
+  return ($base_device, $partition_number);
+}
+
+sub join_device_string {
+  # Given a UNIX base device node string, and an end-user friendly partition number
+  # r returns a combined string that handles NVMe's device naming style in addition to the style used by SATA and
+  # PATA devices.
+  #
+  # Input arguments:
+  #   base_device_node         : Eg, 'sda' or 'nvme0n1'.
+  #   partition_number : Eg, '5' or '3'
+  #
+  # Returns:
+  #     * combined string      : Eg, 'sda5' or 'nvme0n1p3' (notice the 'p' for the NVMe drive)
+  my $base_device_node = $_[0];
+  my $partition_number = $_[1];
+
+  my $joined = "";
+  if ($base_device_node =~ /nvme.*/) {
+    # If the target device node is an NVMe drive, append the letter 'p' (nvme0n1p3)
+    $joined = $base_device_node."p".$partition_number;
+  } else {
+    $joined = $base_device_node.$partition_number;
+  }
+  return $joined;
 }
 
 sub get_drivetype {

--- a/src/livecd/chroot/usr/share/rescuezilla/CHANGELOG
+++ b/src/livecd/chroot/usr/share/rescuezilla/CHANGELOG
@@ -25,7 +25,6 @@
 * Stopped printing of FTP credentials when mounting drives
 * Removed deprecated sfdisk ‘-x’ argument used to save extended partition information
 * Replaced deprecated ‘sfdisk -R’ call with ‘blockdev –rereadpt’, to force reload partition info
-* Fixed Master Boot Record size being incorrectly 32768 bytes, not 512 bytes (thanks louvetch)
 * Writes Rescuezilla version in the backup directory to help backwards compatibility
 * Writes partition information during backup so Ubuntu 18.04 partclone can correctly restore
 * Moved script from /sbin/redobackup to /usr/local/sbin/rescuezilla as per File Hierarchy Standard


### PR DESCRIPTION
Adds support to backup/restore NVMe while maintaining backwards compatibility, but with the limitation that the NVMe backups made with this change _cannot_ be restored using Rescuezilla v1.0.5 (while backups of other formats continue be).