### PR TITLE
Ensure NVMe backups can be restored to non-NVME drives using v1.0.5

### DIFF
--- a/src/livecd/chroot/etc/rc.local
+++ b/src/livecd/chroot/etc/rc.local
@@ -20,4 +20,9 @@ hwclock -s --localtime --noadjfile
 # FIXME: user/group ownership are not tracked.
 chown -R ubuntu:ubuntu /home/ubuntu
 
+# Disable swap partitions as Rescuezilla for disaster recovery from dying disks
+# or in data forensics, situations where writing to a disk is a bad thing.
+# FIXME: Find a way ensure swap is never enabled including early in the boot process.
+swapoff --all
+
 exit 0

--- a/src/livecd/chroot/home/ubuntu/.Xresources
+++ b/src/livecd/chroot/home/ubuntu/.Xresources
@@ -1,6 +1,6 @@
 ! To scale text (for HiDPI monitors) change the DPI configuration
 ! For regular monitors, DPI of 96 is fine
-Xft.dpi: 125
+Xft.dpi: 100
 Xft.antialias: true
 Xft.rgba: rgb
 Xft.hinting: true

--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -381,9 +381,7 @@ sub do_backup {
   print "\t* ".loc("Size of [_1] ([_2] bytes) saved to [_3]",$src_drive,$bytes,$file_size_path)."\n";
   # Save list of partitions we will be backing up
   my @partlist = get_selected_partitions('backup_partitions');
-  my $partlist_str = join("\n", @partlist);
-  my $file_backup_path = "$dest/$file.backup";
-  save_file($partlist_str, $file_backup_path);
+  save_partition_list(\@partlist, "$dest/$file.backup");
   # Get the total bytes we're going to be saving
   #print Dumper(%drives);
   my $total_bytes = 0;
@@ -402,7 +400,6 @@ sub do_backup {
   $status{'done_bytes'} = 0;
   $status{'frame'} = 0;
   $status{'free'} = get_free_space();
-  print "\t* ".loc("Partition list saved to [_1]",$file_backup_path)."\n";
   # Create backup by calling progress sub
   print "\t* ".loc("Total partitions to save: [_1]",$status{'total_parts'})."\n";
   print "\t* ".loc("Total bytes to save: [_1]",$status{'total_bytes'})."\n";
@@ -1977,6 +1974,36 @@ sub join_device_string {
   }
   return $joined;
 }
+
+sub save_partition_list {
+  # Takes an array containing a list of partitions and saves it to an output file. More recent device node patterns,
+  # such as NVMe drives' nvmeAnBpC are rewritten in the format sdzC to preserve the compatibility of Rescuezilla v1.0.5
+  # to be able to restore NVMe partitions to non-NVMe drives as it processes the source partition list during a
+  # restore operation.
+  #
+  # Input arguments:
+  #   partition array: An array containing the partitions being backed up. Eg, 'sda1', 'sda2', 'sda3'.
+  #   output file: Output file to write the partitions separated by a newline (\n)
+  my @partitions = @{$_[0]};
+  my $output_file = $_[1];
+
+  foreach my $part (@partitions) {
+     # During a restore process, the original partition string is processed. Given Rescuezilla v1.0.5 does not
+     # support the NVMe drive pattern (nvmeAnBpC), rewriting any NVMe drive patterns to an sdzC pattern means that
+     # Rescuezilla v1.0.5 is able to restore partitions which were originally backed up from an NVMe devices by
+     # newer version of Rescuezilla.
+     if ($part =~ /nvme.*/) {
+       my ($original_base_device, $original_partition_number) = split_device_string($part);
+       $part = join_device_string("sdz", $original_partition_number);
+     }
+  }
+
+  # Convert array into string with line breaks after each partition
+  my $linebroken_partition_string = join("\n", @partitions);
+  save_file($linebroken_partition_string, $output_file);
+  print "\t* ".loc("Partition list saved to [_1]",$file_backup_path)."\n";
+}
+
 
 sub get_drivetype {
   # Given an "sdX" device, return the string that indicates its type

--- a/src/livecd/chroot/usr/local/sbin/rescuezilla
+++ b/src/livecd/chroot/usr/local/sbin/rescuezilla
@@ -206,6 +206,10 @@ sub main {
   my $welcome = loc("Welcome to Rescuezilla");
   my $tools_msg = loc("Many other tools are available from the Start menu in the bottom left corner");
   system("notify-send \"".$welcome."\" \"".$tools_msg."\" -i info");
+  print loc("Disabling swap partitions")."\n";
+  # Ensure swap is turned off during every launch. Potential gotcha: GParted
+  # reportedly re-enables swap.
+  system("swapoff --all");
   Gtk2->main;
 }
 
@@ -2001,7 +2005,7 @@ sub save_partition_list {
   # Convert array into string with line breaks after each partition
   my $linebroken_partition_string = join("\n", @partitions);
   save_file($linebroken_partition_string, $output_file);
-  print "\t* ".loc("Partition list saved to [_1]",$file_backup_path)."\n";
+  print "\t* ".loc("Partition list saved to [_1]",$output_file)."\n";
 }
 
 


### PR DESCRIPTION
The NVMe backup and restore changes implemented for release v1.0.5.1 is able to backup and restore NVMe drives to other NVMe drives or to SATA/SAS/USB/SCSI/IDE drives. However, in order to be able to restore an NVMe backup to a non-NVMe drive using v1.0.5 the source partition string written the backup needs to be modified to be similar to the SATA/SAS/USB/SCSCI/IDE pattern so it can be processed with v1.0.5.