### PR TITLE
Stop Travis-CI git clone from limiting depth to 50 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: minimal
+language: shell
+
+os: linux
 
 # The build bot OS environment does not really matter, as the docker image
 # provides the primary host environment for the build. However, a more recent
@@ -49,11 +51,11 @@ before_deploy:
 
 deploy:
   provider: releases
-  api_key: $GITHUB_TOKEN
+  token: $GITHUB_TOKEN
   file:
     - build/rescuezilla-$TRAVIS_TAG-64bit.iso
     - build/rescuezilla-$TRAVIS_TAG-32bit.iso
   draft: true
-  skip_cleanup: true
+  cleanup: false
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ dist: bionic
 services:
   - docker
 
+git:
+  # Disable shallow clone, this prevents the build failing when the number of commits
+  # since the last git tag exceeds Travis-CI's default --depth=50 argument, causing the
+  #  `git describe --tags` to error, which causes the deb package build to fail.
+  depth: false
+
 # Launches Docker container to act as 'host system'. See BUILD.ISO.IMAGE.md for more information.
 before_install:
   # Build an immutable docker image from the Dockerfile, labelled with a

--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -6,7 +6,9 @@ Note: [You can download the latest Rescuezilla ISO image here](https://github.co
 
 A single `make deb` command generates a Rescuezilla package ready for installation.
 
-Alternatively, a single `make all` command can generate an AMD64 ISO image and an i386 image, which are complete Ubuntu-based Linux live environments capable of booting from USB sticks, CD, DVD and any EFI firmware, including with EFI Secure Boot switched on. To construct such an ISO image, an Ubuntu 18.04, or similar Ubuntu-package environment capable of running debootstrap, chroot and bind mounts is currently required. Debian and other non-Canonical package environments will not work (see the "EFI Secure Boot" section below).
+Alternatively, a single `make all` command can generate an AMD64 ISO image and an i386 image, which are complete Ubuntu-based Linux live environments capable of booting from USB sticks, CD, DVD and any EFI firmware, including with EFI Secure Boot switched on.
+
+To construct such an ISO image, an Ubuntu 18.04, or similar Ubuntu-package environment capable of running debootstrap, chroot and bind mounts is currently required. However, it's currently recommended _only_ Ubuntu 18.04 (Focal) be used to build the ISO image: older debootstrap versions may not have the scripts to bootstrap an Ubuntu 20.04 Focal package environment, and versions of debootstrap newer than v1.0.106 (2018-07-05) currently don't work due to the reasons described in [#72](https://github.com/rescuezilla/rescuezilla/issues/72). Finally, Debian and other non-Canonical package environments will not work (see the "EFI Secure Boot" section below). To build on environments other than Ubuntu 18.04, see the "Build ISO with docker" section below.
 
 ```bash
 sudo apt-get update

--- a/src/apps/package-as-deb.mk
+++ b/src/apps/package-as-deb.mk
@@ -7,6 +7,10 @@ BUILD_DIR?=build
 ABS_BUILD_PATH=$(abspath $(BUILD_DIR))
 APP_NAME?=NO_APP_NAME_SET
 
+# TODO: When GNU Make 4.2 becomes available in build environment, use $(.SHELLSTATUS) [1]
+# TODO: to check the exit codes of the below shell commands, so improve resilience of this Makefile.
+# [1] https://stackoverflow.com/a/40710111
+
 # Get the most recent git tag (deb files don't support git SHA's, so need to abbreviate)
 LAST_TAGGED_VERSION=$(shell git describe --tags --abbrev=0)
 # Full git version to embed


### PR DESCRIPTION
Configures travis-ci to do a standard complete clone, rather than a shallow clone of the last 50 commits. This fixes an accidentally merged commit that broke the build, as `git describe --tags` returned incorrect results because it's been more than 50 commits since the last git tag.