### PR TITLE
Makes GRUB bootloader prettier, automatic 10s timeout, adds memtest86+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update
 
 RUN apt-get install --yes \
                           # Install required dependencies for the build
-                          make rsync sudo debootstrap squashfs-tools xorriso git gettext dosfstools mtools \
+                          make rsync sudo debootstrap squashfs-tools xorriso memtest86+ git gettext \
+                          dosfstools mtools \
                           shim-signed grub-efi-amd64-signed grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin \
                           devscripts debhelper \
                           # Install optional dependencies for quality-of-life when debugging

--- a/build.sh
+++ b/build.sh
@@ -217,7 +217,7 @@ umount -lf chroot/dev/
 rm chroot/root/.bash_history
 rm chroot/chroot.steps.part.1.sh chroot/chroot.steps.part.2.sh
 
-mkdir -p image/casper image/install
+mkdir -p image/casper image/memtest
 cp chroot/boot/vmlinuz-*-generic image/casper/vmlinuz
 if [[ $? -ne 0 ]]; then
     echo "Error: Failed to copy vmlinuz image."
@@ -229,6 +229,12 @@ chmod 644 image/casper/vmlinuz
 cp chroot/boot/initrd.img-*-generic image/casper/initrd.lz
 if [[ $? -ne 0 ]]; then
     echo "Error: Failed to copy initrd image."
+    exit 1
+fi
+
+cp /boot/memtest86+.bin image/memtest/
+if [[ $? -ne 0 ]]; then
+    echo "Error: Failed to copy memtest86+ binary from host system."
     exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -149,6 +149,29 @@ fi
 # Create Rescuezilla desktop icon
 ln -s /usr/share/applications/rescuezilla.desktop "$BUILD_DIRECTORY/chroot/home/ubuntu/Desktop/rescuezilla.desktop"
 
+LANG_CODES=(
+    "fr"
+    "de"
+    "es"
+)
+
+# Process GRUB locale files
+pushd "$BUILD_DIRECTORY/image/boot/grub/locale/"
+for lang in "${LANG_CODES[@]}"; do
+        if [[ ! -f "$lang.ko" ]]; then
+                echo "Warning: $long.ko translation does not exist. Skipping."
+        else
+                msgfmt --output-file="$lang.mo" "$lang.ko"
+                if [[ $? -ne 0 ]]; then
+                        echo "Error: Unable to convert GRUB bootloader configuration $lang translation from text-based ko format to binary mo format."
+                        exit 1
+                fi
+                # Remove unused *.ko file
+                rm "$app_name.ko"
+        fi
+done
+popd
+
 # Most end-users will not understand the terms i386 and AMD64.
 MEMORY_BUS_WIDTH=""
 if  [ "$ARCH" == "i386" ]; then

--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -16,7 +16,7 @@ sudo apt-get update
 # recent version of debootstrap (from the backports repository) to bootstrap a Focal environment.
 sudo apt-get install git-lfs git make sudo \
                      rsync debootstrap gettext squashfs-tools dosfstools mtools xorriso \
-                     devscripts debhelper \
+                     memtest86+ devscripts debhelper \
                      # GRUB bootloader and support modules for booting both MBR and EFI boot
                      # across CPU architectures. Notably the AMD64 image *legacy boot* uses
                      # the same 32-bit bootloader as the i386 image.

--- a/src/livecd/image/boot/grub/grub.cfg
+++ b/src/livecd/image/boot/grub/grub.cfg
@@ -2,6 +2,7 @@
 insmod all_video
 insmod gfxterm
 insmod png
+insmod gettext
 
 loadfont "unicode"
 terminal_output gfxterm
@@ -28,120 +29,66 @@ set gfxmode=auto
 
 # This variable may be set to a directory containing a GRUB graphical menu theme. 
 set theme=/boot/grub/theme/theme.txt
+set locale_dir=/boot/grub/locale
 
-submenu "English" {
-    set theme=/boot/grub/theme/theme.txt
-    menuentry "Start Rescuezilla" {
-        linux  /casper/vmlinuz boot=casper quiet splash fastboot fsck.mode=skip --
-        initrd /casper/initrd.lz
+# Creates menu item with translated menu entries.
+#
+# Usage:
+# lang    : Internally used GRUB environment variable to ISO 639-1 code (eg, fr) which is used to load translation .mo file
+# tag     : Country-code, eg "FR". This is used to form the full lagnuage tag, eg fr_FR
+# language: Human-readable name of language (eg, French)
+#
+# Note GRUB variable do not propagate contexts (https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1175127), so have to keep
+# re-assigning variable every context change.
+function create_menu {
+    set language="$1"
+    set lang="$2"
+    # Set non-GRUB internal environment variable to language tag (eg, fr_FR)
+    set tag="$3"
+    # Set Linux kernel boot options for locale (language, keyboard layout etc)
+    set locale_opts="locale=${lang}_${tag} bootkbd=${tag} console-setup/layoutcode=${tag}"
+
+    submenu $language $lang "$locale_opts" {
+        # Re-assign internal GRUB variables, cleared through change of context
+        set lang="$2"
+        set theme=/boot/grub/theme/theme.txt
+        shift 2
+        set locale_opts="$@"
         # If boot fails, reboot and try selecting Safe Mode instead
-    }
+        menuentry $"Start Rescuezilla" "$locale_opts" {
+            shift 1
+            set locale_opts="$@"
+            linux  /casper/vmlinuz boot=casper quiet splash fastboot fsck.mode=skip $locale_opts --
+            initrd /casper/initrd.lz
+        }
 
-    menuentry "Safe Mode" {
-        linux  /casper/vmlinuz boot=casper xforcevesa nomodeset vga=791 toram --
-        initrd /casper/initrd.lz
         # Prompts for a video mode and loads the USB image into RAM
-    }
+        menuentry $"Safe Mode" $locale_opts {
+            shift 1
+            set locale_opts="$@"
+            linux  /casper/vmlinuz boot=casper xforcevesa nomodeset vga=791 toram fsck.mode=skip $locale_opts --
+            initrd /casper/initrd.lz
+        }
 
-    menuentry "Check USB for defects" {
-        # The absence of fsck.mode=skip causes md5sum to be checked, to help detect bitrot data corruption
-        linux  /casper/vmlinuz boot=casper quiet splash fastboot --
-        initrd /casper/initrd.lz
-        # Verify integrity of USB drive
-    }
+       # Verify integrity of USB drive
+        menuentry $"Check USB for defects" $locale_opts {
+            shift 1
+            set locale_opts="$@"
+            # The absence of fsck.mode=skip causes md5sum to be checked, to help detect bitrot data corruption
+            linux  /casper/vmlinuz boot=casper quiet splash fastboot $locale_opts --
+            initrd /casper/initrd.lz
+        }
 
-    if [ ${grub_platform} == "efi" ]; then
-        menuentry "Enter BIOS Setup" {
-            fwsetup
+        if [ ${grub_platform} == "efi" ]; then
             # Configure machine's firmware, boot options etc
-        }
-    fi
+            menuentry $"Enter BIOS Setup" {
+                fwsetup
+            }
+        fi
+    }
 }
 
-submenu "Français" {
-    set theme=/boot/grub/theme/theme.txt
-    loadfont "unicode"
-    menuentry "Démarrer Redo Backup" {
-        linux  /casper/vmlinuz boot=casper quiet splash fastboot fsck.mode=skip locale=fr_FR bootkbd=fr console-setup/layoutcode=fr --
-        initrd /casper/initrd.lz
-        # Si le boot échoue, rebootez et réessayez en selectionnant le mode sans échec à la place
-    }
-
-    menuentry "Mode sans échec" {
-        linux  /casper/vmlinuz boot=casper xforcevesa nomodeset vga=791 toram locale=fr_FR bootkbd=fr console-setup/layoutcode=fr --
-        initrd /casper/initrd.lz
-        # Propose un mode vidéo et charge l'image CD en mémoire
-    }
-
-    menuentry "Contrôle du CD" {
-        # The absence of fsck.mode=skip causes md5sum to be checked, to help detect bitrot data corruption
-        linux  /casper/vmlinuz boot=casper quiet splash locale=fr_FR bootkbd=fr console-setup/layoutcode=fr --
-        initrd /casper/initrd.lz
-        # Vérifie l'intégrité du CD
-    }
-
-    if [ ${grub_platform} == "efi" ]; then
-        # FIXME: Translate
-        menuentry "Enter BIOS Setup" {
-            fwsetup
-        }
-    fi
-}
-
-submenu "Deutsch" {
-    set theme=/boot/grub/theme/theme.txt
-    menuentry "Rescuezilla" {
-        linux  /casper/vmlinuz boot=casper quiet splash fastboot fsck.mode=skip locale=de bootkbd=de console-setup/layoutcode=de console-setup/variantcode=nodeadkeys --
-        initrd /casper/initrd.lz
-        # Startet Rescuezilla. Sollte das Booten hiermit nicht  möglich sein, bitte den Abgesicherten Modus versuchen.
-    }
-
-    menuentry "Abgesicherter Modus" {
-        linux  /casper/vmlinuz boot=casper noacpi nolapic nomsi xforcevesa nomodeset vga=791 toram locale=de bootkbd=de console-setup/layoutcode=de console-setup/variantcode=nodeadkeys --
-        initrd /casper/initrd.lz
-        # Versucht das Redo System mit einer Hardware unabhängigeren Konfiguration zu starten.
-    }
-
-    menuentry "Contrôle du CD" {
-        # The absence of fsck.mode=skip causes md5sum to be checked, to help detect bitrot data corruption
-        linux  /casper/vmlinuz boot=casper quiet splash locale=de bootkbd=de console-setup/layoutcode=de console-setup/variantcode=nodeadkeys --
-	    initrd /casper/initrd.lz
-        # Prüft den Arbeitsspeicher (RAM) auf Fehler
-    }
-
-    if [ ${grub_platform} == "efi" ]; then
-        # FIXME: Translate
-        menuentry "Enter BIOS Setup" {
-            fwsetup
-        }
-    fi
-}
-
-submenu "Español" {
-    set theme=/boot/grub/theme/theme.txt
-    menuentry "Iniciar Rescuezilla" {
-        linux  /casper/vmlinuz boot=casper quiet splash fastboot fsck.mode=skip locale=es_ES bootkbd=es console-setup/layoutcode=es --
-        initrd /casper/initrd.lz
-        # Si el arranque falla, reinicie e intente seleccionando en su lugar el modo a prueba de fallos
-    }
-
-    menuentry "Modo seguro" {
-        linux  /casper/vmlinuz boot=casper xforcevesa nomodeset vga=791 toram locale=es_ES bootkbd=es console-setup/layoutcode=es --
-        initrd /casper/initrd.lz
-        # Solicita un modo de vídeo y carga la imagen USB en la RAM
-    }
-
-    menuentry "Comprobar si hay defectos en la USB" {
-        # The absence of fsck.mode=skip causes md5sum to be checked, to help detect bitrot data corruption
-        linux  /casper/vmlinuz boot=casper quiet splash locale=es_ES bootkbd=es console-setup/layoutcode=es --
-	    initrd /casper/initrd.lz
-        # Compruebe si hay errores en la memoria del computador
-    }
-
-    if [ ${grub_platform} == "efi" ]; then
-        # FIXME: Translate
-        menuentry "Enter BIOS Setup" {
-            fwsetup
-        }
-    fi
-}
+create_menu "English"  "en" "US" 
+create_menu "Français" "fr" "FR"
+create_menu "Deutsch"  "de" "DE" 
+create_menu "Español"  "es" "ES"

--- a/src/livecd/image/boot/grub/grub.cfg
+++ b/src/livecd/image/boot/grub/grub.cfg
@@ -1,18 +1,33 @@
-set default=0
-set gfxmode=auto
-
+# Documentation: https://www.gnu.org/software/grub/manual/grub/grub.html
 insmod all_video
 insmod gfxterm
 insmod png
 
 loadfont "unicode"
-
-set color_normal=light-blue/black
-set menu_color_normal=white/light-blue
-set menu_color_highlight=red/white
-set theme=/boot/grub/theme/theme.txt
-
 terminal_output gfxterm
+
+# If this variable is set, it specifies the time in seconds to wait for keyboard input before booting the default menu
+# entry. A timeout of ‘0’ means to boot the default entry immediately without displaying the menu; a timeout of ‘-1’ (or
+# unset) means to wait indefinitely.
+set timeout=10
+# This variable may be set to ‘menu’, ‘countdown’, or ‘hidden’ to control the way in which the timeout (see timeout)
+# interacts with displaying the menu. 
+timeout_style=menu
+
+# If this variable is set, it identifies a menu entry that should be selected by default, possibly after a timeout
+# (see timeout). The entry may be identified by number (starting from 0 at each level of the hierarchy), by title, or by id.
+set default=0
+
+# If this variable is set, it sets the resolution used on the ‘gfxterm’ graphical terminal. Note that you can only use modes which
+# your graphics card supports via VESA BIOS Extensions (VBE), so for example native LCD panel resolutions may not be available. The default
+# is ‘auto’, which selects a platform-specific default that should look reasonable. Supported modes can be listed by ‘videoinfo’ command in GRUB.
+#
+# The resolution may be specified as a sequence of one or more modes, separated by commas (‘,’) or semicolons (‘;’); each will be tried in turn
+# until one is found. Each mode should be either ‘auto’, ‘widthxheight’, or ‘widthxheightxdepth’.
+set gfxmode=auto
+
+# This variable may be set to a directory containing a GRUB graphical menu theme. 
+set theme=/boot/grub/theme/theme.txt
 
 submenu "English" {
     set theme=/boot/grub/theme/theme.txt
@@ -23,7 +38,6 @@ submenu "English" {
     }
 
     menuentry "Safe Mode" {
-        set gfxpayload=keep
         linux  /casper/vmlinuz boot=casper xforcevesa nomodeset vga=791 toram --
         initrd /casper/initrd.lz
         # Prompts for a video mode and loads the USB image into RAM
@@ -45,24 +59,24 @@ submenu "English" {
 }
 
 submenu "Français" {
-    loadfont "unicode"
     set theme=/boot/grub/theme/theme.txt
+    loadfont "unicode"
     menuentry "Démarrer Redo Backup" {
         linux  /casper/vmlinuz boot=casper quiet splash fastboot fsck.mode=skip locale=fr_FR bootkbd=fr console-setup/layoutcode=fr --
-	    initrd /casper/initrd.lz
+        initrd /casper/initrd.lz
         # Si le boot échoue, rebootez et réessayez en selectionnant le mode sans échec à la place
     }
 
     menuentry "Mode sans échec" {
         linux  /casper/vmlinuz boot=casper xforcevesa nomodeset vga=791 toram locale=fr_FR bootkbd=fr console-setup/layoutcode=fr --
-	    initrd /casper/initrd.lz
+        initrd /casper/initrd.lz
         # Propose un mode vidéo et charge l'image CD en mémoire
     }
 
     menuentry "Contrôle du CD" {
         # The absence of fsck.mode=skip causes md5sum to be checked, to help detect bitrot data corruption
         linux  /casper/vmlinuz boot=casper quiet splash locale=fr_FR bootkbd=fr console-setup/layoutcode=fr --
-	    initrd /casper/initrd.lz
+        initrd /casper/initrd.lz
         # Vérifie l'intégrité du CD
     }
 

--- a/src/livecd/image/boot/grub/grub.cfg
+++ b/src/livecd/image/boot/grub/grub.cfg
@@ -85,6 +85,15 @@ function create_menu {
                 fwsetup
             }
         fi
+
+        # Memtest86+ does not support UEFI boot, and GRUB does not support chainloading non-UEFI binaries. Therefore,
+        # only display memory test on legacy PC boot (in other words only display when machine is *not* booted in UEFI mode)
+        if [ ${grub_platform} == "pc" ]; then
+            # Check computer memory for errors
+            menuentry $"Memory test" {
+                linux16 /memtest/memtest86+.bin
+            }
+        fi
     }
 }
 

--- a/src/livecd/image/boot/grub/locale/de.ko
+++ b/src/livecd/image/boot/grub/locale/de.ko
@@ -1,0 +1,42 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-27 14:12+0930\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Start Rescuezilla"
+msgstr "Rescuezilla"
+
+msgid "If boot fails, reboot and try selecting Safe Mode instead"
+msgstr "Startet Rescuezilla. Sollte das Booten hiermit nicht  möglich sein, bitte den Abgesicherten Modus versuchen."
+
+msgid "Safe Mode"
+msgstr "Abgesicherter Modus"
+
+msgid "Prompts for a video mode and loads the USB image into RAM"
+msgstr "Versucht das Redo System mit einer Hardware unabhängigeren Konfiguration zu starten."
+
+msgid "Check USB for defects"
+msgstr "Rescuezilla CD prüfen"
+
+msgid "Verify integrity of USB drive"
+msgstr "Prüft die eingelegte Rescuezilla CD auf Defekte."
+
+msgid "Enter BIOS Setup"
+msgstr ""
+
+msgid "Configure machine's firmware, boot options etc"
+msgstr ""

--- a/src/livecd/image/boot/grub/locale/de.ko
+++ b/src/livecd/image/boot/grub/locale/de.ko
@@ -40,3 +40,9 @@ msgstr ""
 
 msgid "Configure machine's firmware, boot options etc"
 msgstr ""
+
+msgid "Memory test"
+msgstr "(RAM) prüfen"
+
+msgid "Check computer memory for errors"
+msgstr "Prüft den Arbeitsspeicher (RAM) auf Fehler"

--- a/src/livecd/image/boot/grub/locale/es.ko
+++ b/src/livecd/image/boot/grub/locale/es.ko
@@ -1,0 +1,42 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-27 14:12+0930\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Start Rescuezilla"
+msgstr "Iniciar Rescuezilla"
+
+msgid "If boot fails, reboot and try selecting Safe Mode instead"
+msgstr "Si el arranque falla, reinicie e intente seleccionando en su lugar el modo a prueba de fallos"
+
+msgid "Safe Mode"
+msgstr "Modo seguro"
+
+msgid "Prompts for a video mode and loads the USB image into RAM"
+msgstr "Solicita un modo de vídeo y carga la imagen USB en la RAM"
+
+msgid "Check USB for defects"
+msgstr "Comprobar si hay defectos en la USB"
+
+msgid "Verify integrity of USB drive"
+msgstr "Compruebe si hay errores en la memoria del computador"
+
+msgid "Enter BIOS Setup"
+msgstr ""
+
+msgid "Configure machine's firmware, boot options etc"
+msgstr ""

--- a/src/livecd/image/boot/grub/locale/es.ko
+++ b/src/livecd/image/boot/grub/locale/es.ko
@@ -40,3 +40,9 @@ msgstr ""
 
 msgid "Configure machine's firmware, boot options etc"
 msgstr ""
+
+msgid "Memory test"
+msgstr "Prueba de memoria"
+
+msgid "Check computer memory for errors"
+msgstr "Compruebe si hay errores en la memoria del computador"

--- a/src/livecd/image/boot/grub/locale/fr.ko
+++ b/src/livecd/image/boot/grub/locale/fr.ko
@@ -1,0 +1,42 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-27 14:12+0930\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Start Rescuezilla"
+msgstr "Démarrer Redo Backup"
+
+msgid "If boot fails, reboot and try selecting Safe Mode instead"
+msgstr "Si le boot échoue, rebootez et réessayez en selectionnant le mode sans échec à la place"
+
+msgid "Safe Mode"
+msgstr "Mode sans échec"
+
+msgid "Prompts for a video mode and loads the USB image into RAM"
+msgstr "Propose un mode vidéo et charge l'image CD en mémoire"
+
+msgid "Check USB for defects"
+msgstr "Vérifie l'intégrité du CD"
+
+msgid "Verify integrity of USB drive"
+msgstr "Vérifie l'intégrité du CD"
+
+msgid "Enter BIOS Setup"
+msgstr ""
+
+msgid "Configure machine's firmware, boot options etc"
+msgstr ""

--- a/src/livecd/image/boot/grub/locale/fr.ko
+++ b/src/livecd/image/boot/grub/locale/fr.ko
@@ -40,3 +40,9 @@ msgstr ""
 
 msgid "Configure machine's firmware, boot options etc"
 msgstr ""
+
+msgid "Memory test"
+msgstr "test mémoire"
+
+msgid "Check computer memory for errors"
+msgstr "Test la mémoire de l'ordinateur"

--- a/src/livecd/image/boot/grub/theme/select_c.png
+++ b/src/livecd/image/boot/grub/theme/select_c.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eea10790519964f8e4f9c15f7160c9c48cb033fa2c11dfd1343d6ea54cc3857
+size 896

--- a/src/livecd/image/boot/grub/theme/select_e.png
+++ b/src/livecd/image/boot/grub/theme/select_e.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33802d0becdaef8eeff54d3395120f268a76c1a356cdc8a049e8bc54c8f47fbc
+size 884

--- a/src/livecd/image/boot/grub/theme/select_w.png
+++ b/src/livecd/image/boot/grub/theme/select_w.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07d30501a137c6fc04e6e2979fc0d7e89fb4c7e19e02f09c382c69b770465408
+size 886

--- a/src/livecd/image/boot/grub/theme/theme.txt
+++ b/src/livecd/image/boot/grub/theme/theme.txt
@@ -1,22 +1,28 @@
+# Documentation: https://www.gnu.org/software/grub/manual/grub/grub.html#Theme-file-format
+
 desktop-image: "bg_redo.png"
 desktop-image-scale-method: "crop"
 
-title-color: "black"
-title-font: "DejaVu Sans Bold 16"
+# Not using 'title-text' (nor 'title-color' and 'title-font') as it seems to have limited flexibility in positioning.
+title-text: ""
 
-# Example title text                                                Rescuezilla X.Y.Z 64bit 20XX-YY-ZZT012345
-title-text: "                                                       Rescuezilla VERSION-SUBSTITUTED-BY-BUILD-SCRIPT MEMORY-BUS-WIDTH-SUBSTITUTED-BY-BUILD-SCRIPT GIT-COMMIT-DATE-SUBSTITUTED-BY-BUILD-SCRIPT"
 message-font: "Unifont Regular 16"
 terminal-font: "Unifont Regular 16"
 
-#help bar at the bottom
+# Display version information using label field
 + label {
-        top = 100%-50
-        left = 55%
-        width = 45%
-        height = 20
-        text = "@KEYMAP_SHORT@"
-        align = "center"
+        # The distance from the left border of container to left border of the object in either of three formats:
+        #
+        # x     Value in pixels
+        # p%    Percentage
+        # p%+x  mixture of both
+        left = 0%
+        top = 5%
+        width = 100%
+        height = 10%
+        # This field is modified by the build scripts, typically in the form: "X.Y.Z 64bit 20XX-YY-ZZT012345"
+        text = "VERSION-SUBSTITUTED-BY-BUILD-SCRIPT MEMORY-BUS-WIDTH-SUBSTITUTED-BY-BUILD-SCRIPT GIT-COMMIT-DATE-SUBSTITUTED-BY-BUILD-SCRIPT"
+        align = "right"
         color = "black"
         font = "DejaVu Sans Bold 16"
 }
@@ -24,13 +30,14 @@ terminal-font: "Unifont Regular 16"
 #boot menu
 + boot_menu {
         left = 60%
-        width = 40%
         top = 20%
-        height = 90%
-        item_color = "black"
+        width = 40%
+        height = 55%
         item_font = "DejaVu Sans Bold 14"
-        selected_item_color= "#ffffff"
-        selected_item_font = "Unifont Regular 16"
+        item_color = "black"
+        selected_item_color = "white"
+        # The image file pattern for the selected item highlight styled box.
+        selected_item_pixmap_style = "select_*.png"
         item_height = 16
         item_padding = 0
         item_spacing = 4
@@ -39,3 +46,39 @@ terminal-font: "Unifont Regular 16"
         item_icon_space = 0
 }
 
+# Countdown for automatic booting of the default menu option
++ progress_bar {
+        left = 55%
+        top = 75%
+        width = 40%
+        # Height parameter does not seem to be respected for some reason (bar too thick)
+        height = 3%
+        # The text to display. If “id“ is set to “__timeout__“ and no “text“ property is set then the amount of seconds will be shown.
+        id = "__timeout__"
+        # The border color for plain solid color rendering.
+        # (Using a color from the background image)
+        fg_color = "#345278"
+        # The background color for plain solid color rendering.
+        bg_color = "white"
+        # The border color for plain solid color rendering.
+        border_color = "black"
+        text_color = "#F39721"
+        font = "DejaVu Sans Bold 6"
+        # The text to display on the progress bar. If the progress bar’s ID is set to “__timeout__“ and the value of this property is set to
+        # “@TIMEOUT_NOTIFICATION_SHORT@“, “@TIMEOUT_NOTIFICATION_MIDDLE@“ or “@TIMEOUT_NOTIFICATION_LONG@“, then GRUB will update this property
+        # with an informative message as the timeout approaches.
+        text = "@TIMEOUT_NOTIFICATION_MIDDLE@"
+}
+
+
+# Hotkey legend bar (the "Press 'e' to edit boot options" menu)
++ label {
+        left = 0%
+        top = 90%
+        width = 100%
+        height = 10%
+        text = "@KEYMAP_SHORT@"
+        align = "right"
+        color = "black"
+        item_font = "DejaVu Sans Bold 14"
+}


### PR DESCRIPTION
Configured GRUB with menu item highlighting, progress bars for automatic 10 second boot.

Refactored grub.cfg into functions and used gettext based localization.

Returned memtest86+ (as was the case for Rescuezilla v1.0.5.1), as turns out GRUB menu configuration allows items to not be shown when booted on PC boot or EFI boot, which is required given memtest86+ is a 16-bit program that needs MBR boot (and GRUB doesn't support chainloading).