### PR TITLE
Adds Japanese translation by AE720

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Rescuezilla has been translated into the following languages:
 * Polski (pl-PL)
 * Italiano (it-IT)
 * Ελληνικά (el-GR) ([Translation complete](https://github.com/rescuezilla/rescuezilla/issues/171))
+* 日本語 (ja-JP) ([Translation complete (needs review)](https://github.com/rescuezilla/rescuezilla/issues/176))
 
 **Rescuezilla is now officially open for translations! See [Translations HOWTO](https://github.com/rescuezilla/rescuezilla/wiki/Translations-HOWTO) to submit a translation.**
 

--- a/build.sh
+++ b/build.sh
@@ -159,6 +159,7 @@ LANG_CODES=(
     "pl"
     "it"
     "el"
+    "ja"
 )
 
 # Process GRUB locale files

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -134,6 +134,9 @@ common_pkgs=("discover"
              "firefox-locale-pl"
              "firefox-locale-it"
              "firefox-locale-el"
+             "firefox-locale-ja"
+             "fonts-takao-mincho"
+             "ibus-anthy"
              "breeze-gtk-theme"
              "gtk3-engines-breeze"
              "gnome-icon-theme"
@@ -201,6 +204,7 @@ common_pkgs=("discover"
              "language-pack-gnome-pl-base"
              "language-pack-gnome-it-base"
              "language-pack-gnome-el-base"
+             "language-pack-gnome-ja-base"
 )
 
 if  [ "$ARCH" == "i386" ]; then

--- a/src/apps/graphical-shutdown/graphical-shutdown/usr/share/locale/ja/LC_MESSAGES/graphical-shutdown.ko
+++ b/src/apps/graphical-shutdown/graphical-shutdown/usr/share/locale/ja/LC_MESSAGES/graphical-shutdown.ko
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"Language: ja\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "End Session"
+msgstr "セッションを終了する"
+
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgid "Shutdown"
+msgstr "シャットダウン"
+
+msgid "Reboot"
+msgstr "リブート"
+
+msgid "Choose action."
+msgstr "アクションを選択してください"

--- a/src/apps/rescuezilla/rescuezilla/usr/share/locale/ja/LC_MESSAGES/rescuezilla.ko
+++ b/src/apps/rescuezilla/rescuezilla/usr/share/locale/ja/LC_MESSAGES/rescuezilla.ko
@@ -1,0 +1,428 @@
+# Japanese translation of Rescuezilla
+# Copyright (C) 2021
+# This file is distributed under the same license as the PACKAGE package.
+# AE720, 2021
+# Submitted at: https://github.com/rescuezilla/rescuezilla/issues/176
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-25 20:36+1030\n"
+"PO-Revision-Date: 2021-01-24 00:00+0000\n"
+"Last-Translator: AE720\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Welcome"
+msgstr "ようこそ"
+
+msgid "Select an Option"
+msgstr "オプションを選択してください"
+
+msgid "Easily create a backup image of your computer, or completely restore from one.  Click an option to begin:"
+msgstr "コンピュータのバックアップイメージを簡単に作成し、1つから完全にレストアします.\n\n オプションをクリックして開始します:"
+
+msgid "Backup"
+msgstr "バックアップ"
+
+msgid "Restore"
+msgstr "レストア"
+
+msgid "Need help? Start by checking the Rescuezilla frequently asked questions, then proceed to the Rescuezilla forum."
+msgstr "ヘルプが必要ですか? Rescuezillaのよくある質問を\n確認することから始め、次にRescuezillaフォーラムに進みます。"
+
+msgid "Consider contributing $1/month on the crowdfunding website Patreon so Rescuezilla can continue to be developed."
+msgstr "Rescuezillaを開発し続けることができるように、\nクラウドファンディングサイトPatreonの$ 1 /月の貢献を検討してください。"
+
+msgid "Back"
+msgstr "戻る"
+
+msgid "Next >"
+msgstr "次へ >"
+
+msgid "Please wait..."
+msgstr "お待ちください..."
+
+msgid "Identifying disk drives..." 
+msgstr "ディスクドライブの識別..."
+
+msgid "Step 1: Select Drive To Backup"
+msgstr "ステップ1: バックアップするディスクドライブを選択してください"
+
+msgid "Select the source drive that you would like to create a backup image from."
+msgstr "バックアップイメージをソースドライブを選択します。"
+
+msgid "Drive"
+msgstr "ディスクドライブ"
+
+msgid "Capacity"
+msgstr "容量"
+
+msgid "Drive Model"
+msgstr "モデル"
+
+msgid "Partitions"
+msgstr "パーティション"
+
+msgid "Show hidden devices (for advanced users)"
+msgstr "非表示のドライブを表示する (上級ユーザー向け)"
+
+msgid "Step 2: Select Partitions to Save"
+msgstr "ステップ2: 保存するパーティションたちを選択してください"
+
+msgid "Select which partitions to create a backup of.  Leave all partitions selected if you are unsure."
+msgstr "バックアップを作成するパーティションたちを選択します。 不明な場合は、すべてのパーティションを選択したままにします。"
+
+msgid "Save"
+msgstr "保存する"
+
+msgid "Description"
+msgstr "デスクリプション"
+
+msgid "Drive {drive_number}, Partition {partition_number}"
+msgstr "ドライブ {drive_number}, パーティション {partition_number}"
+
+msgid "Drive {drive_number}"
+msgstr "ドライブ {drive_number}"
+
+msgid "Step 3: Select Destination Drive"
+msgstr "ステップ3: 保存先ドライブを選択します"
+
+msgid "Click on the box below to select the source drive that you would like to create a backup image from."
+msgstr "下のボックスをクリックして、バックアップイメージのソースドライブを選択します。"
+
+msgid "Connected directly to my computer"
+msgstr "コンピューターに直接接続する"
+
+msgid "Shared over a network"
+msgstr "ネットワーク経由で共有する"
+
+msgid "Where is the destination drive?"
+msgstr "保存先ドライブはどこですか？"
+
+msgid "SMB/CIFS shared folder specified below"
+msgstr "以下に指定されているSMB / CIFS共有フォルダー"
+
+msgid "Search network"
+msgstr "検索ネットワーク"
+
+msgid "Server or share location:"
+msgstr "サーバーか共有フォルダーへアクセス:"
+
+msgid "Username (Optional):"
+msgstr "ユーザー名 (任意信号):"
+
+msgid "Password (Optional):"
+msgstr "パスワード (任意信号):"
+
+msgid "Domain (Optional):"
+msgstr "ドメイン (任意信号):"
+
+msgid "Version (Optional):"
+msgstr "バージョン (任意信号):"
+
+msgid "Select network-shared storage location:"
+msgstr "共有フォルダーへアクセスを選択します:"
+
+msgid "Select destination drive:"
+msgstr "保存先ディスクを選択します:"
+
+msgid "Partition"
+msgstr "パーティション"
+
+msgid "Mounting..."
+msgstr "マウント処理。。。"
+
+msgid "Please ensure the username, password and other fields provided are correct, and try again."
+msgstr "パスワードと他のフィールドが正しく、もう一度試してください。"
+
+msgid "Scanning folder for backup images..."
+msgstr "バックアップイメージのフォルダを検索しています。。。"
+
+msgid "Error processing the following images:"
+msgstr "次のイメージにエラーが情報処理しました:"
+
+msgid "Unable to fully process the image associated with the following partitions:"
+msgstr "次のパーティションたちに関連付けられているイメージを完全に処理できません:"
+
+msgid "Unable to fully process the following image:"
+msgstr "次のイメージを完全に処理できません："
+
+msgid "This can happen when loading images which Clonezilla was unable to completely backup. Any other filesystems within the image should be restorable as normal."
+msgstr "これは、Clonezillaが完全にバックアップできなかったイメージをロードするときに発生する可能性があります。イメージ内の他のファイルシステムは、通常どおりレストア可能である必要があります。"
+
+msgid "Needs decryption"
+msgstr "復号化が必要"
+
+msgid "Unknown filesystem"
+msgstr "不明なファイルシステム"
+
+# No need to translate this message into your language -- it's only relevant for an old unofficial French version.
+msgid "The backup's extended partition information is empty or missing. This happens with incomplete backups created by an unofficial Redo Backup update. If the backup contains extended partitions, these will not restore correctly. All data is still fully recoverable but manual intervention is required to fully restore the extended partitions. Please consult {url} for information and assistance. The destination drive has not yet been modified. Do you wish to continue with the restore?"
+msgstr ""
+
+# No need to translate this message into your language -- it's only relevant for an old unofficial German version.
+msgid "The backup's bootloader data is shorter than expected. This happens with backups created by an unofficial Redo Backup update. If the backup contained certain bootloaders like GRUB, the restored hard drive will not boot correctly without a manual fix. All data is still fully recoverable but manual intervention may required to restore the bootloader. Please consult {url} for information and assistance. The destination drive has not yet been modified. Do you wish to continue with the restore?"
+msgstr "Die Bootloader-Daten des Backups sind weniger als erwartet. Dies kommt bei Sicherungen vor, die durch ein inoffizielles Redo-Backup-Update erstellt wurden. Wenn das Backup bestimmte Bootloader wie GRUB enthielt, lässt sich die wiederhergestellte Festplatte ohne manuelle Fehlerbehebung nicht ordnungsgemäß starten. Alle Daten können vollständig wiederhergestellt werden, womöglich ist jedoch ein manueller Eingriff erforderlich, um den Bootloader wiederherzustellen. Informationen und Unterstützung erhalten Sie unter %1 Das Ziellaufwerk wurde noch nicht geändert. Möchten Sie mit der Wiederherstellung fortfahren?"
+
+msgid "Step 4: Select Destination Folder"
+msgstr "ステップ4: 保存先フォルダを選択します"
+
+msgid "Click <b>Browse</b> to select the folder on the destination drive where your new backup image will be saved.\n"
+"\n"
+"The folder a backup is saved in is usually a description of the computer, e.g. <b>office1</b> or <b>zack-laptop</b>."
+msgstr "[バロース]をクリックして、新しいバックアップイメージがレストアされる宛先ドライブ上のフォルダーを選択します。 "
+"\n"
+"バックアップがレストアされるフォルダは通常、コンピュータの説明です 例えば <b>office1</b> または <b>zack-laptop</b>。"
+
+msgid "You must select a folder inside {location}"
+msgstr "{場所}のフォルダを選択する必要があります"
+
+msgid "Please select a different folder."
+msgstr "別のフォルダを選択してください。"
+
+msgid "The table below lists the backup images that already in this folder (if any)."
+msgstr "次の表に、このフォルダにすでにあるバックアップイメージを示します (もしあれば)。"
+
+msgid "Browse..."
+msgstr "ブラウズ。。"
+
+msgid "Filename"
+msgstr "ファイル名"
+
+msgid "Size"
+msgstr "サイズ"
+
+msgid "Last modified"
+msgstr "最終更新日"
+
+msgid "When you are happy with the destination folder, click <b>Next</b>."
+msgstr "保存先フォルダを選択したら、[次へ]をクリックします。"
+
+msgid "Step 5: Name Your Backup"
+msgstr "ステップ 5: バックアップに名前を付ける"
+
+msgid "Provide a unique name for this backup image, such as the date.  Today's date is automatically entered for you below.\n"
+"\n"
+"You may only use letters, numbers, and dashes in your backup name."
+msgstr "日付など、このバックアップイメージの一意の名前を指定します。今日の日付は以下に自動的に入力されます。"
+"\n"
+"バックアップ名には、文字、数字、ダッシュのみを使用できます。"
+
+msgid "Step 6: Confirm Backup Configuration"
+msgstr "ステップ 6: バックアップ構成を確認する"
+
+msgid "Source drive"
+msgstr "ソースドライブ"
+
+msgid "Backing up the following partition"
+msgstr "次のパーティションをバックアップします"
+
+msgid "The backup image will be written into folder {dest_dir} on {description}"
+msgstr "バックアップイメージは、{description}のフォルダ{dest_dir}に書き込まれます。."
+
+msgid "Confirm the following backup configuration."
+msgstr "次のバックアップ構成を確認してください。"
+
+msgid "To start the backup, click <b>Next</b>."
+msgstr "バックアップを開始するには、[<b>次へ</b>]をクリックします。"
+
+msgid "Step 7: Creating Backup Image"
+msgstr "ステップ 7: バックアップイメージの作成をしています。。。"
+
+msgid "Backing up your system to the location you selected.  This may take an hour or more depending on the speed of your computer and the amount of data."
+msgstr "選択した場所にシステムをバックアップしています。 コンピュータの速度とデータの量によっては、これに1時間以上かかる場合があります。"
+
+msgid "Time Elapsed / Remaining: "
+msgstr "経過時間/残り時間: "
+
+msgid "Backup {partition_name} containing filesystem {filesystem} to {destination}"
+msgstr "ファイルシステム{filesystem}を含む{partition_name}を{destination}にバックアップします。"
+
+msgid "Summary of Backup"
+msgstr "バックアップの概要"
+
+msgid "Confirm the backup summary."
+msgstr "バックアップの概要を確認してください。"
+
+msgid "Backup Summary"
+msgstr "バックアップの概要"
+
+msgid "Backup cancelled by user."
+msgstr "ユーザーによってバックアップがキャンセルされました。"
+
+msgid "Error creating backup: "
+msgstr "バックアップの作成中にエラーが発生しました。"
+
+msgid "Failed to write destination file. Please confirm it is valid to create the provided file path, and try again."
+msgstr "保存先ファイルの書き込みに失敗しました。 ファイルが有効であることを確認して、再試行してください。"
+
+msgid "Successful backup of swap partition {partition_name}"
+msgstr "スワップパーティションのバックアップは成功しました。 {partition_name}"
+
+msgid "<b>Failed to backup partition</b> {partition_name}"
+msgstr "<b>パーティションのバックアップに失敗しました</b> {partition_name}"
+
+msgid "Successful backup of partition {partition_name}"
+msgstr "パーティションのバックアップが成功しました {partition_name}"
+
+msgid "Backup saved successfully."
+msgstr "バックアップが正常に保存されました"
+
+msgid "Backup succeeded with some errors:"
+msgstr "バックアップはいくつかのエラーで成功しました：:"
+
+msgid "Backup operation failed:"
+msgstr "バックアップ論理演算に失敗しました:"
+
+msgid "Operation took {num_minutes} minutes."
+msgstr "演算時間は{num_minutes}分かかりました。"
+
+msgid "To start a new session, click <b>Next</b>"
+msgstr "新しいセッションを開始するには、[<b>次へ</b>]をクリックします。"
+
+msgid "Step 1: Select Image Location"
+msgstr "ステップ 1: イメージの場所を選択します。"
+
+msgid "Where is the source drive?"
+msgstr "ソースドライブはどこにありますか?"
+
+msgid "Select source drive:"
+msgstr "ソースドライブを選択します。:"
+
+msgid "Step 2: Select Backup Image"
+msgstr "ステップ 2: バックアップドライブを選択します。"
+
+msgid "Click the box below to select the folder containing image files."
+msgstr "下のボックスをクリックして、イメージファイルを含むフォルダを選択します。"
+
+msgid "Select the image file to restore"
+msgstr "レストアするイメージファイルを選択します。"
+
+msgid "Date created"
+msgstr "作成日時"
+
+msgid "Step 3: Select Drive To Restore"
+msgstr "ステップ 3: ドライブを選択してレストアします"
+
+msgid "Select the destination drive you wish to overwrite and restore the selected image to."
+msgstr "書きする望んだデスティネーションドライブを選択し、選択したイメージをレストアします。"
+
+msgid "Step 4: Select Partitions To Restore"
+msgstr "ステップ 4: レストアするパーティションたちを選択します"
+
+msgid "Select which partitions from the backup to restore, and whether to overwrite the partition table. Leave everything selected to completely restore the destination drive."
+msgstr "レストアするバックアップからパーティションたちを選択して, 書きするかどうかをパーティションテーブルを決める。 デスティネーションドライブを完全にレストアするにはすべてを選択したままにする。"
+
+msgid "Selected image"
+msgstr "選択したイメージ"
+
+msgid "Destination device"
+msgstr "保存先バイス"
+
+msgid "IMPORTANT: Only selecting FIRST disk in Clonezilla image containing MULTIPLE DISKS."
+msgstr "警告: <b>複数のディスク</b>を含むclonezillaイメージの<b>最初</b>のディスクのみを選択します。"
+
+msgid "Destination partition"
+msgstr "デスティネーションデスティネーション"
+
+msgid "Overwrite partition table"
+msgstr "パーティションテーブルを上書きします"
+
+msgid "You will be overwriting the partition table."
+msgstr "パーティションテーブルを上書きします。"
+
+msgid "The \"destination partition\" column has been updated using the information stored within the backup image.\n\n<b>If partitions have been resized, new partitions added, or additional operating systems installed <i>since the backup image was created</i>, then the destination drive's partition table will not match the backup image, and overwriting the destination drive's partition table will render these resized and additional partitions permanently inaccessible.</b> If you have not modified the partition table in such a way since creating this backup then overwriting the partition table is completely safe and will have no negative effects."
+msgstr "「デスティネーションデスティネーション」列は、バックアップイメージ内にレストアされている情報を使用して更新されました。\n\n<b>バックアップイメージの<i>作成日時に<i>パーティションのサイズが変更されたり、新しいパーティションたちが追加されたり、オペレーティングシステムが追加されたりした場合は、デスティネーションドライブのパーティションテーブルがバックアップイメージと一致しなくて, デスティネーションドライブのパーティションテーブルを書きすると、これらのサイズ変更された追加のパーティションたちに永続的にアクセスできなくなります。このバックアップを作成してからそのような方法でパーティションテーブルを変更していない場合、パーティションテーブルを書きしても完全に安全です。"
+
+msgid "You will <b>not</b> be overwriting the partition table."
+msgstr "パーティションテーブルを上書きすることはありません。"
+
+msgid "The \"destination partition\" column has been updated with destination drive's existing partition table information.\n\n<b>The destination partition column can be modified as a dropdown menu. Incorrectly mapping the destination partitions may cause operating systems to no longer boot.</b> If you are unsure of the mapping, consider if it's more suitable to instead overwrite the partition table."
+msgstr "「デスティネーションパーティション 」列が、デスティネーションドライブの既存のパーティションテーブル情報で更新されました。\n\n<b>デスティネーションパーティション 列は、ドロップダウンメニューとして変更できます。 宛先パーティションを誤ってマッピングすると、オペレーティングシステムが起動しなくなる可能性があります。</b> よくわからない場合は、代わりにパーティションテーブルを上書きする方が適切かどうかを検討してください。"
+
+msgid "No destination partition selected. Use the destination partition drop-down menu to select the destination"
+msgstr "デスティネーションパーティションが選択されていません。ドロップダウンメニューを使用して、保存先を選択します。"
+
+msgid "Step 5: Confirm Restore Configuration"
+msgstr "ステップ 5: レストアのコンフィギュレーションを確認します。"
+
+msgid "Confirm the restore configuration."
+msgstr "レストアのコンフィギュレーションを確認してください。"
+
+msgid "Are you sure you want to restore the backup to {destination_drive}? Doing so will permanently overwrite the data on this drive!"
+msgstr "バックアップを{destination_drive}にレストアしてもよろしいですか？ これを行うと、このドライブのデータが完全に上書きされます。"
+
+msgid "Source image"
+msgstr "ソースイメージ"
+
+msgid "Destination drive"
+msgstr "デスティネーションドライブ"
+
+msgid "Restoring the following partitions"
+msgstr "次のパーティションをレストアしっています"
+
+msgid "WILL BE OVERWRITING PARTITION TABLE"
+msgstr "パーティションテーブルを上書きします"
+
+msgid "Will <b>NOT</b> be overwriting partition table"
+msgstr "パーティションテーブルを上書きすることは<b>ありません</b>"
+
+msgid "To start the restore, click <b>Next</b>."
+msgstr "レストアを開始するには、[次へ]をクリックします."
+
+msgid "Restoring From Backup"
+msgstr "バックアップからのレストアをしています。。。"
+
+msgid "Restoring your system from the image you selected.  This may take an hour or more depending on the speed of your computer and the amount of data."
+msgstr "選択したイメージからシステムをレストアをしています。 パソコンの速度やデータ量によっては、1時間以上かかる場合があります。"
+
+msgid "Refreshing partition table"
+msgstr "パーティションテーブルをリフレッシュしています。"
+
+msgid "Restoring {description} to {destination_partition} ({destination_description})"
+msgstr "{description}を{destination_partition}にレストアします ({destination_description})"
+
+msgid "Restore cancelled by user."
+msgstr "ユーザーによってキャンセルされたレストア。"
+
+msgid "Error restoring image: "
+msgstr "イメージのレストア中にエラーが発生しました:"
+
+msgid "Could not restore sfdisk partition table as file has zero length: "
+msgstr "ファイルの長さがゼロであるため、sfdiskパーティションテーブルをレストアできませんでした:"
+
+msgid "Successfully restored partition table."
+msgstr "パーティションテーブルのレストアは成功しました。"
+
+msgid "Failed to refresh the devices' partition table. This can happen if another process is accessing the partition table."
+msgstr "デバイスのパーティションテーブルの更新に失敗しました。 別のプロセスがパーティションテーブルにアクセスしている場合に発生します。"
+
+msgid "Unable to restore partition {destination_partition} because there is no saved image associated with: {description}."
+msgstr "{description}に関連付けられた保存済みイメージがないため、パーティション{destination_partition}をレストアできません。"
+
+msgid "This may occur if Clonezilla was originally unable to backup this partition."
+msgstr "これは、Clonezillaが元々このパーティションをバックアップできなかった場合に発生する可能性があります。"
+
+msgid "Error restoring partition {image_key} to {destination_partition}."
+msgstr "パーティション{image_key}を{destination_partition}にレストア中にエラーが発生しました。"
+
+msgid "Successfully restored image partition {image} to {destination_partition}"
+msgstr "イメージパーティション{image}は{destination_partition}に成功しました"
+
+msgid "Summary of Restore"
+msgstr "レストアの概要"
+
+msgid "Restore Summary"
+msgstr "レストアの概要"
+
+msgid "Confirm the restore summary."
+msgstr "レストアの概要を確認してください。"
+
+msgid "Backup restored successfully."
+msgstr "バックアップのレストアは成功しました。" 

--- a/src/livecd/chroot/etc/locale.nopurge
+++ b/src/livecd/chroot/etc/locale.nopurge
@@ -55,3 +55,5 @@ it
 it_IT.UTF-8
 el
 el_GR.UTF-8
+ja
+ja_JP.UTF-8

--- a/src/livecd/image/boot/grub/grub.cfg
+++ b/src/livecd/image/boot/grub/grub.cfg
@@ -118,3 +118,4 @@ create_menu "Português(brasileiro)" "pt" "BR" "console-setup/layoutcode=br boot
 create_menu "Polski" "pl" "PL" "console-setup/layoutcode=pl bootkbd=pl"
 create_menu "Italiano" "it" "IT" "console-setup/layoutcode=it bootkbd=it"
 create_menu "Ελληνικά" "el" "GR" "console-setup/layoutcode=el bootkbd=el"
+create_menu "日本語" "ja" "JP" "console-setup/layoutcode=ja bootkbd=ja"

--- a/src/livecd/image/boot/grub/locale/ja.ko
+++ b/src/livecd/image/boot/grub/locale/ja.ko
@@ -1,0 +1,55 @@
+# Japanese translation of Rescuezilla
+# Copyright (C) 2021
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Submitted at: https://github.com/rescuezilla/rescuezilla/issues/176
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-27 14:12+0930\n"
+"PO-Revision-Date: 2021-01-24 00:00+0000\n"
+"Last-Translator: AE720 <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Start Rescuezilla"
+msgstr "Rescuezillaを起動する"
+
+msgid "If boot fails, reboot and try selecting Graphical fallback instead"
+msgstr "起動が失敗した場合は グラフィカルなフォールバックモードを選択してみてください"
+
+msgid "Graphical fallback mode"
+msgstr "グラフィカルなフォールバックモード"
+
+msgid "Use low-resolution fallback graphics driver if standard mode doesn't work for your hardware"
+msgstr "ハードウェアで標準モードが機能しない場合はグラフィカルなフォールバックモードを使用する"
+
+msgid "Load USB into RAM"
+msgstr "USBをRAMにロードする"
+
+msgid "Loads Rescuezilla into memory allowing the boot media to be ejected after bootup"
+msgstr "Rescuezillaをメモリにロードし、起動後に起動メディアを排出できるようにします"
+
+msgid "Check USB for defects"
+msgstr "欠陥のためにUSBをチェックする"
+
+msgid "Verify integrity of USB drive"
+msgstr "USBドライブの整合性を確認"
+
+msgid "Enter BIOS Setup"
+msgstr "BIOSセットアップに入る"
+
+msgid "Configure machine's firmware, boot options etc"
+msgstr "マシンのファームウェア、ブートオプションを構成などコンフィグする"
+
+msgid "Memory test"
+msgstr "メモリテスト"
+
+msgid "Check computer memory for errors"
+msgstr "コンピュータのメモリにエラーがないかチェックする"


### PR DESCRIPTION
Adds Japanese (ja-JA) translation by GitHub user AE720 [1].  Also adds keyboard
layout and GNOME language packs as relevant.

For input, ibus-anthy [2] has been installed but not configured. Switching to
Google Japanese Input based ibus-mozc [3] needs to be evaluated.

Future review by a native speaker is suggested as this is a non-native
translation: the user suggested they translated the application for practice.

[1] https://github.com/rescuezilla/rescuezilla/issues/176

[2] https://packages.ubuntu.com/focal/ibus-anthy

[3] https://packages.ubuntu.com/focal/ibus-mozc

Fixes #176