### PR TITLE
Small improvements for the French translation

### DIFF
--- a/src/apps/graphical-shutdown/graphical-shutdown/usr/share/locale/fr/LC_MESSAGES/graphical-shutdown.ko
+++ b/src/apps/graphical-shutdown/graphical-shutdown/usr/share/locale/fr/LC_MESSAGES/graphical-shutdown.ko
@@ -8,7 +8,7 @@ msgid "End Session"
 msgstr "Quitter la session"
 
 msgid "Cancel"
-msgstr "Cancel"
+msgstr "Annuler"
 
 msgid "Shutdown"
 msgstr "Arrêter"

--- a/src/apps/rescuezilla/rescuezilla/usr/share/locale/fr/LC_MESSAGES/rescuezilla.ko
+++ b/src/apps/rescuezilla/rescuezilla/usr/share/locale/fr/LC_MESSAGES/rescuezilla.ko
@@ -26,7 +26,7 @@ msgid "Select an Option"
 msgstr "Sélectionnez une option"
 
 msgid "Easily create a backup image of your computer, or completely restore from one.  Click an option to begin:"
-msgstr "Créez facilement une sauvegarde de votre PC, ou restaurez-le à partir d'une sauvegarde.   Choisissez une option pour commencer"
+msgstr "Créez facilement une sauvegarde de votre PC, ou restaurez-le à partir d'une sauvegarde. Choisissez une option pour commencer :"
 
 msgid "Backup"
 msgstr "Sauvegarder"
@@ -74,7 +74,7 @@ msgid "Show hidden devices (for advanced users)"
 msgstr "Afficher les appareils masqués (pour les utilisateurs avancés)"
 
 msgid "Step 2: Select Partitions to Save"
-msgstr "Etape 2: Choix des partitions à sauvegarder"
+msgstr "Étape 2 : Choix des partitions à sauvegarder"
 
 msgid "Select which partitions to create a backup of.  Leave all partitions selected if you are unsure."
 msgstr "Sélectionnez les partitions que vous voulez sauvegarder. Laissez toutes les partitions sélectionnées si vous n'êtes pas sûr."
@@ -92,7 +92,7 @@ msgid "Drive {drive_number}"
 msgstr "Disque {drive_number}"
 
 msgid "Step 3: Select Destination Drive"
-msgstr "Etape 3: Sélectionnez la destination de la sauvegarde"
+msgstr "Étape 3 : Sélectionnez la destination de la sauvegarde"
 
 msgid "Click on the box below to select the source drive that you would like to create a backup image from."
 msgstr "Cliquez sur la zone ci-dessous pour sélectionner le disque dont vous voulez réaliser une image."
@@ -116,22 +116,22 @@ msgid "Server or share location:"
 msgstr "Emplacement du serveur ou du partage :"
 
 msgid "Username (Optional):"
-msgstr "Nom d'utilisateur (optionnel):"
+msgstr "Nom d'utilisateur (optionnel) :"
 
 msgid "Password (Optional):"
-msgstr "Mot de passe : (optionnel):"
+msgstr "Mot de passe (optionnel) :"
 
 msgid "Domain (Optional):"
-msgstr "Domaine : (optionnel):"
+msgstr "Domaine (optionnel) :"
 
 msgid "Version (Optional):"
-msgstr ""
+msgstr "Version (optionnel) :"
 
 msgid "Select network-shared storage location:"
 msgstr "Choisir l'emplacement de stockage partagé sur le réseau :"
 
 msgid "Select destination drive:"
-msgstr "Sélectionnez le disque de destination:"
+msgstr "Sélectionnez le disque de destination :"
 
 msgid "Partition"
 msgstr "Partition"
@@ -155,7 +155,7 @@ msgid "Unable to fully process the following image:"
 msgstr "Impossible de traiter complètement l'image suivante :"
 
 msgid "This can happen when loading images which Clonezilla was unable to completely backup. Any other filesystems within the image should be restorable as normal."
-msgstr "Cela peut se produire lors du chargement d'images dont Clonezilla n'a pu totalement sauvegardé. Tout autre système de fichiers au sein de l'image doit pouvoir être restauré normalement."
+msgstr "Cela peut se produire lors du chargement d'images dont Clonezilla n'a pu totalement sauvegarder. Tout autre système de fichiers au sein de l'image doit pouvoir être restauré normalement."
 
 msgid "Needs decryption"
 msgstr "Doit être décrypté"
@@ -172,7 +172,7 @@ msgid "The backup's bootloader data is shorter than expected. This happens with 
 msgstr ""
 
 msgid "Step 4: Select Destination Folder"
-msgstr "Etape 4: Sélectionnez le répertoire de sauvegarde"
+msgstr "Étape 4 : Sélectionnez le répertoire de sauvegarde"
 
 msgid "Click <b>Browse</b> to select the folder on the destination drive where your new backup image will be saved.\n"
 "\n"
@@ -206,14 +206,14 @@ msgid "When you are happy with the destination folder, click <b>Next</b>."
 msgstr "Lorsque vous êtes satisfait du dossier de destination, cliquez sur <b>Suivant</b>."
 
 msgid "Step 5: Name Your Backup"
-msgstr "Etape 5: Donnez un nom à votre sauvegarde"
+msgstr "Étape 5 : Donnez un nom à votre sauvegarde"
 
 msgid "Provide a unique name for this backup image, such as the date.  Today's date is automatically entered for you below.\n"
 "\n"
 "You may only use letters, numbers, and dashes in your backup name."
-msgstr "Fournissez un nom unique pour cette sauvegarde, tel que la date.  La date du jour est automatiquement proposée par la suite."
+msgstr "Fournissez un nom unique pour cette sauvegarde, tel que la date. La date du jour est automatiquement proposée par la suite."
 "\n"
-"Vous ne pouvez utiliser que des lettres, des nombres et des tirets dans le nom de la sauvegarde."
+"Vous pouvez utiliser que des lettres, des chiffres et des tirets dans le nom de la sauvegarde."
 
 msgid "Step 6: Confirm Backup Configuration"
 msgstr "Étape 6 : confirmez la configuration de sauvegarde"
@@ -234,13 +234,13 @@ msgid "To start the backup, click <b>Next</b>."
 msgstr "Pour débuter la sauvegarde, cliquez sur <b>Suivant</b>."
 
 msgid "Step 7: Creating Backup Image"
-msgstr "Etape 7: Création de la sauvegarde"
+msgstr "Étape 7 : Création de la sauvegarde"
 
 msgid "Backing up your system to the location you selected.  This may take an hour or more depending on the speed of your computer and the amount of data."
-msgstr "Sauvegarde du système sur l'emplacement sélectionné.  Cela peut prendre du temps et dépend de la puissance de votre PC et de la taille des données."
+msgstr "Sauvegarde du système sur l'emplacement sélectionné. Cela peut prendre du temps et dépend de la puissance de votre PC et de la taille des données."
 
 msgid "Time Elapsed / Remaining: "
-msgstr "Temps passé / restant :"
+msgstr "Temps écoulé / restant :"
 
 msgid "Backup {partition_name} containing filesystem {filesystem} to {destination}"
 msgstr "Sauvegarder {partition_name} contenant le système de fichier {filesystem} vers {destination}"
@@ -297,10 +297,10 @@ msgid "Select source drive:"
 msgstr "Sélectionner le disque source :"
 
 msgid "Step 2: Select Backup Image"
-msgstr "Etape 2: Sélectionnez l'image à restaurer"
+msgstr "Étape 2 : Sélectionnez l'image à restaurer"
 
 msgid "Click the box below to select the folder containing image files."
-msgstr "Cliquez sur la cas ci-dessous pour sélectionner le dossier contenant les fichiers images."
+msgstr "Cliquez sur la case ci-dessous pour sélectionner le dossier contenant les fichiers images."
 
 msgid "Select the image file to restore"
 msgstr "Choisir le fichier image à restaurer"
@@ -309,7 +309,7 @@ msgid "Date created"
 msgstr "Date créée"
 
 msgid "Step 3: Select Drive To Restore"
-msgstr "Etape 3: Sélectionnez le disque à restaurer"
+msgstr "Étape 3 : Sélectionnez le disque à restaurer"
 
 msgid "Select the destination drive you wish to overwrite and restore the selected image to."
 msgstr "Choisissez le disque de destination que vous souhaitez écraser et sur lequel restaurer l'image sélectionnée."
@@ -318,7 +318,7 @@ msgid "Step 4: Select Partitions To Restore"
 msgstr "Étape 4 : sélectionnez les partitions à restaurer"
 
 msgid "Select which partitions from the backup to restore, and whether to overwrite the partition table. Leave everything selected to completely restore the destination drive."
-msgstr "Sélectionnez quelles partitions de la sauvegarde restaurer, et si écraser la table des partitions. Laissez tout sélectionné pour restaurer complètement le disque de destination."
+msgstr "Sélectionnez quelles partitions de la sauvegarde à restaurer, et si la table de partition doit être écrasée. Laissez tout sélectionné pour restaurer complètement le disque de destination."
 
 msgid "Selected image"
 msgstr "Image sélectionnée"
@@ -327,7 +327,7 @@ msgid "Destination device"
 msgstr "Appareil de destination"
 
 msgid "IMPORTANT: Only selecting FIRST disk in Clonezilla image containing MULTIPLE DISKS."
-msgstr "IMPORTANT : sélection uniquement du PREMIER disque de l'image Clonezilla contenant PLUSIEURS DISQUES."
+msgstr "IMPORTANT : sélectionnez uniquement le PREMIER disque de l'image Clonezilla contenant PLUSIEURS DISQUES."
 
 msgid "Destination partition"
 msgstr "Partition de destination"
@@ -348,7 +348,7 @@ msgid "The \"destination partition\" column has been updated with destination dr
 msgstr "La colonne \"partition de destination\" a été mise à jour avec les informations de la table de partition existante du lecteur de destination. \n\n<b>La colonne de la partition de destination peut être modifiée comme un menu déroulant. Le mappage inexact des partitions de destination peut provoquer le non démarrage des systèmes d'exploitation. </b> Si vous n'êtes pas sûr du mappage, voyez s'il ne serait pas plus approprié d'écraser la table des partitions."
 
 msgid "No destination partition selected. Use the destination partition drop-down menu to select the destination"
-msgstr "Aucune destination de partition sélectionnée. Utilisez le menu déroulant de partitions de destination pour choisir la destination"
+msgstr "Aucune partition de destination sélectionnée. Utilisez le menu déroulant de partitions de destination pour choisir la destination"
 
 msgid "Step 5: Confirm Restore Configuration"
 msgstr "Étape 5 : Confirmez la configuration de restauration"
@@ -381,7 +381,7 @@ msgid "Restoring From Backup"
 msgstr "Restauration à partir d'une sauvegarde"
 
 msgid "Restoring your system from the image you selected.  This may take an hour or more depending on the speed of your computer and the amount of data."
-msgstr "Restaure le système à partir de la sauvegarde sélectionnée.  Cela peut prendre du temps et dépend de la puissance de votre PC et de la taille des données."
+msgstr "Restaure le système à partir de la sauvegarde sélectionnée. Cela peut prendre du temps et dépend de la puissance de votre PC et de la taille des données."
 
 msgid "Refreshing partition table"
 msgstr "Actualisation de la table de partition"

--- a/src/livecd/image/boot/grub/locale/fr.ko
+++ b/src/livecd/image/boot/grub/locale/fr.ko
@@ -21,34 +21,34 @@ msgid "Start Rescuezilla"
 msgstr "Démarrer Redo Backup"
 
 msgid "If boot fails, reboot and try selecting Graphical fallback instead"
-msgstr ""
+msgstr "Si le démarrage échoue, redémarrez et essayez plutôt de sélectionner le mode de secours graphique"
 
 msgid "Graphical fallback mode"
 msgstr "Mode de secours graphique"
 
 msgid "Use low-resolution fallback graphics driver if standard mode doesn't work for your hardware"
-msgstr ""
+msgstr "Utilisez le mode de secour graphique à basse résolution si le mode standard ne fonctionne pas pour votre matériel"
 
 msgid "Load USB into RAM"
 msgstr "Charger l'USB dans la RAM"
 
 msgid "Loads Rescuezilla into memory allowing the boot media to be ejected after bootup"
-msgstr "" 
+msgstr "Charge Rescuezilla en mémoire, ce qui permet d'éjecter le support d'amorçage après le démarrage" 
 
 msgid "Check USB for defects"
-msgstr "Vérifie l'intégrité du CD"
+msgstr "Vérifie l'intégrité du disque"
 
 msgid "Verify integrity of USB drive"
-msgstr "Vérifie l'intégrité du CD"
+msgstr "Vérifie l'intégrité du disque"
 
 msgid "Enter BIOS Setup"
-msgstr ""
+msgstr "Entrez dans la configuration du BIOS"
 
 msgid "Configure machine's firmware, boot options etc"
-msgstr ""
+msgstr "Configurer le micrologiciel de la machine, les options de démarrage, etc."
 
 msgid "Memory test"
-msgstr "test mémoire"
+msgstr "Test mémoire"
 
 msgid "Check computer memory for errors"
-msgstr "Test la mémoire de l'ordinateur"
+msgstr "Teste la mémoire de l'ordinateur"


### PR DESCRIPTION
The main improvements are:
  - space before ':', '?', and '!';
  - 'Étape' instead of 'Etape';
  - single space after fullstop.

_Note: the Image Explorer strings are hardcoded. Maybe an issue should be created as a reminder for a future translation._