### PR TITLE
Updated README to use Weblate for translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ Rescuezilla has been translated into the following languages:
 * 日本語 (ja-JP)
 * Svenska (sv-SE) ([Translation complete](https://github.com/rescuezilla/rescuezilla/issues/186))
 * 简体中文 (zh-CN) ([Translation complete](https://github.com/rescuezilla/rescuezilla/issues/191))
- 
-**Rescuezilla is now officially open for translations! See [Translations HOWTO](https://github.com/rescuezilla/rescuezilla/wiki/Translations-HOWTO) to submit a translation.**
+
+To translate Rescuezilla:
+
+1. Visit [Weblate](https://hosted.weblate.org/projects/rescuezilla/#languages)
+2. Choose an existing language, or add a new language
+3. Translate as much Rescuezilla as you like!
 
 ## Screenshots
 


### PR DESCRIPTION
Updates README file to remove the link to the Translation HOWTO, has
Rescuezilla has switched to using the collaborative webtool 'Weblate', and
updating the README file to refer to Weblate is a requirement of Weblate's
libre hosting billing. https://hosted.weblate.org/projects/rescuezilla/rescuezilla/