### PR TITLE
Improving build speed using ccache (compiler cache), RAM disk and parallel jobs

### DIFF
--- a/chroot.steps.part.2.sh
+++ b/chroot.steps.part.2.sh
@@ -63,6 +63,12 @@ nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOF
 
+# Leave pigz installed in the chroot but revert the system back to regular gzip
+update-alternatives --remove gzip /bin/pigz
+update-alternatives --remove gzip /bin/real_gzip
+
+mv /bin/real_gzip /bin/gzip
+
 rm -rf /tmp/*
 rm -rf /var/lib/apt/lists/????????*
 umount -lf /proc

--- a/configure_mirror.sh
+++ b/configure_mirror.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Use netselect to configure the closes and hopefully fasted mirror for apt pacakge downloads
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root. Please consult build instructions."
+   exit 1
+fi
+## ensure netselect is installed
+NETSELECT_x64=http://ftp.au.debian.org/debian/pool/main/n/netselect/netselect_0.3.ds1-29_amd64.deb
+NETSELECT_FILE=netselect_0.3.ds1-29_amd64.deb
+
+wget $NETSELECT_x64
+dpkg -i $NETSELECT_FILE
+
+# figure out the fastest / closest mirror to wherever you are
+FASTMIRROR=`netselect -s 10 -t 20 $(wget -qO - mirrors.ubuntu.com/mirrors.txt) | head -1 | cut -d" " -f5`
+
+## fix up the ubuntu server addresses to speed downloads
+sed --in-place "s#http://archive.ubuntu.com/ubuntu#$FASTMIRROR#g" build.sh
+
+# apparently sed doesnt like sub directories
+cd src/livecd/chroot/etc/apt
+sed --in-place "s#http://archive.ubuntu.com/ubuntu#$FASTMIRROR#g" sources.list

--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -24,10 +24,10 @@ sudo apt-get install git-lfs git make sudo \
                      shim-signed grub-efi-amd64-signed \
                      libtool-bin gawk pkg-config comerr-dev docbook-xsl e2fslibs-dev fuse \
                      libaal-dev libblkid-dev libbsd-dev libext2fs-dev libncurses5-dev \
-                     libncursesw5-dev libntfs-3g88 libreadline-gplv2-dev libreadline5 \
+                     libncursesw5-dev libntfs-3g883 libreadline-gplv2-dev libreadline5 \
                      libreiser4-dev libtinfo-dev libxslt1.1 nilfs-tools ntfs-3g ntfs-3g-dev \
                      quilt sgml-base uuid-dev vmfs-tools xfslibs-dev xfsprogs xml-core \
-                     xsltproc
+                     xsltproc ccache
 
 git lfs clone https://github.com/rescuezilla/rescuezilla
 cd rescuezilla/
@@ -36,6 +36,16 @@ git submodule init
 git submodule update --recursive
 # Optional: Build only the standalone deb packages without bothering with the live environment
 make deb
+# Optional: Move build environment to RAMDISK for increased build perfomance
+# This process is manual as not everyone will want to do this.
+# First check that your build system has a minimum of 8Gb available ram then
+# Make sure you remember to clean the environment copy and ISO produced
+# and move everything back to disk when you are done.
+sudo mount -t tmpfs -o rw,size=7G tmpfs /mnt/ramdisk/
+# Next rsync the working rescuezilla directories into the ramdisk
+# Adjust paths as needed
+rsync -av /home/*USER*/rescuezilla /mnt/ramdisk/
+# cd /mnt/ramdisk/rescuezilla and work from there.
 # Build the amd64 ISO image based on Ubuntu 20.04 (Focal), and the deb files.
 # This should work on Ubuntu or Ubuntu-derived distributions, but is _not_ recommended
 # Debian or Debian-derived environments (see "EFI Secure Boot" section below).

--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -34,22 +34,27 @@ cd rescuezilla/
 git submodule init
 # Download 'partclone' and 'util-linux' submodules
 git submodule update --recursive
+
 # Optional: Build only the standalone deb packages without bothering with the live environment
 make deb
+
 ## Optional : set the configure_mirrors.sh file as executable
 chmod +x configure_mirror.sh
 # run the file - this will isntall netselect and should configure Ubuntu mirrors to be the fastest and closest to you
 sudo ./configure_mirror.sh
+
 # Optional: Move build environment to RAMDISK for increased build perfomance
 # This process is manual as not everyone will want to do this.
 # First check that your build system has a minimum of 8Gb available ram then
 # Make sure you remember to clean the environment copy and ISO produced
 # and move everything back to disk when you are done.
 sudo mount -t tmpfs -o rw,size=7G tmpfs /mnt/ramdisk/
+
 # Next rsync the working rescuezilla directories into the ramdisk
 # Adjust paths as needed
 rsync -av /home/*USER*/rescuezilla /mnt/ramdisk/
 # cd /mnt/ramdisk/rescuezilla and work from there.
+
 # Build the amd64 ISO image based on Ubuntu 20.04 (Focal), and the deb files.
 # This should work on Ubuntu or Ubuntu-derived distributions, but is _not_ recommended
 # Debian or Debian-derived environments (see "EFI Secure Boot" section below).

--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -36,6 +36,10 @@ git submodule init
 git submodule update --recursive
 # Optional: Build only the standalone deb packages without bothering with the live environment
 make deb
+## Optional : set the configure_mirrors.sh file as executable
+chmod +x configure_mirror.sh
+# run the file - this will isntall netselect and should configure Ubuntu mirrors to be the fastest and closest to you
+sudo ./configure_mirror.sh
 # Optional: Move build environment to RAMDISK for increased build perfomance
 # This process is manual as not everyone will want to do this.
 # First check that your build system has a minimum of 8Gb available ram then


### PR DESCRIPTION
Patches and notes to speed up rescuezilla build environment.

Exact speed up will depend on the underlying hardware, internet connection speed and the ability to use a RAMDISK for the build.

Previous builds took approximately 23 minutes on modern hardware with SSD.

Modified builds on the same hardware with cold compiler cache take approximately  9 minutes

Modified builds with hot compiler cache take approximately 6 mins 30 seconds.

YMMV