### PR TITLE
Jammy 22.04 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg.cache/*
 /**/*.swp
 /**/__pycache__
 /**/*.pyc
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.DEFAULT_GOAL := focal
-.PHONY: all focal impish i386 deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-utils partclone-nbd install test integration-test clean-build-dir clean clean-all
+.DEFAULT_GOAL := jammy
+.PHONY: all focal impish jammy i386 deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-utils partclone-nbd install test integration-test clean-build-dir clean clean-all
 
 # FIXME: Properly specify the build artifacts to allow the GNU make to actually be smart about what gets built and when.
 # FIXME: This lack of specifying dependency graph means requires eg, `make focal` and `make impish` has to be done as separate invocations
@@ -32,6 +32,12 @@ impish: CODENAME=impish
 export ARCH CODENAME
 impish: deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-utils partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) ./build.sh
+	
+jammy: ARCH=amd64
+jammy: CODENAME=jammy
+export ARCH CODENAME
+jammy: deb sfdisk.v2.20.1.amd64 partclone-utils partclone-nbd $(buildscripts)
+	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) ./build.sh	
 
 # ISO image based on Ubuntu 18.04 Bionic LTS (Long Term Support) 32bit (the last 32bit/i386 Ubuntu LTS release)
 i386: ARCH=i386

--- a/build.sh
+++ b/build.sh
@@ -310,7 +310,7 @@ fi
 # Create manifest
 chroot chroot dpkg-query -W --showformat='${Package} ${Version}\n' > image/casper/filesystem.manifest
 cp -v image/casper/filesystem.manifest image/casper/filesystem.manifest-desktop
-REMOVE='ubiquity ubiquity-frontend-gtk ubiquity-frontend-kde casper lupin-casper live-initramfs user-setup discover xresprobe os-prober libdebian-installer4'
+REMOVE='ubiquity ubiquity-frontend-gtk ubiquity-frontend-kde casper live-initramfs user-setup discover xresprobe os-prober libdebian-installer4'
 for i in $REMOVE; do
   sed -i "/${i}/d" image/casper/filesystem.manifest-desktop
 done

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -103,6 +103,22 @@ pkgs_specific_to_ubuntu2110_impish=(
                        "nbdkit"
 )
 
+pkgs_specific_to_ubuntu2204_jammy=(
+			"linux-generic"
+                        "xserver-xorg"
+                        "xserver-xorg-video-all"
+                        "xserver-xorg-video-intel"
+                        "xserver-xorg-video-qxl"
+                        "xserver-xorg-video-mga"
+                        # Packages which may assist users needing to do a GRUB repair (64-bit EFI)
+                       "shim-signed"
+                       "grub-efi-amd64-signed"
+                       "grub-efi-amd64-bin"
+                       "grub-efi-ia32-bin"
+                       # Dependency for partclone-utils' imagemount
+                       "nbdkit"
+)
+
 # Languages on the system
 lang_codes=(
              "ca"
@@ -250,6 +266,8 @@ elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "focal" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2004_focal[@]}" "${common_pkgs[@]}")
 elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "impish" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2110_impish[@]}" "${common_pkgs[@]}")
+elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "jammy" ]; then
+  apt_pkg_list=("${pkgs_specific_to_ubuntu2204_jammy[@]}" "${common_pkgs[@]}")
 else
   echo "Warning: unknown CPU arch $ARCH or Ubuntu release codename $CODENAME"
   exit 1

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -143,7 +143,7 @@ done
 common_pkgs=("discover"
              "laptop-detect"
              "casper"
-             "lupin-casper"
+             #"lupin-casper" is deprecated
              "openbox"
              "lightdm"
              # Firmware package for NVidia cards from ~2009 (newer cards have firmware in the kernel)
@@ -180,7 +180,8 @@ common_pkgs=("discover"
              "arandr"
              "xfce4-terminal"
              "lxpanel"
-             "ttf-ubuntu-font-family"
+             #"ttf-ubuntu-font-family" is deprecated. fonts-ubuntu is the right one.
+             "fonts-ubuntu"
              "alsamixergui"
              "volumeicon-alsa"
              "pm-utils"
@@ -220,7 +221,8 @@ common_pkgs=("discover"
              "jfsutils"
              "wget"
              "exfat-fuse"
-             "exfat-utils"
+             #"exfat-utils" is replaced with exfatprogs
+             "exfatprogs"
              "btrfs-progs"
              "udisks2-btrfs"
              "hfsplus"

--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -16,15 +16,15 @@ To construct such an ISO image, an Ubuntu 18.04, or similar Ubuntu-package envir
 # executed by Rescuezilla's TravisCI build bot automatically so is contantly being tested. The exact instructions below
 # sometimes gets out-of-date, especially if your build environment is based on a different version of Debian or Ubuntu.
 
-sudo apt-get update
-sudo apt-get install git-lfs git make sudo \
+sudo apt update
+sudo apt install -f git-lfs git make sudo \
                      rsync debootstrap gettext squashfs-tools dosfstools mtools xorriso \
                      memtest86+ devscripts debhelper checkinstall cmake \
                      grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin \
                      shim-signed grub-efi-amd64-signed \
-                     libtool-bin gawk pkg-config comerr-dev docbook-xsl e2fslibs-dev fuse \
-                     libaal-dev libblkid-dev libbsd-dev libext2fs-dev libncurses5-dev \
-                     libncursesw5-dev libntfs-3g88 libreadline-gplv2-dev libreadline5 \
+                     libtool-bin gawk pkg-config comerr-dev docbook-xsl e2fslibs-dev \
+                     libaal-dev libblkid-dev libbsd-dev libncurses5-dev \
+                     libncursesw5-dev readline-common \
                      libreiser4-dev libtinfo-dev libxslt1.1 nilfs-tools ntfs-3g ntfs-3g-dev \
                      quilt sgml-base uuid-dev vmfs-tools xfslibs-dev xfsprogs xml-core \
                      xsltproc ccache


### PR DESCRIPTION
It needs a symlink in debootstrap. Don't know how to make it with GitHub online editor. I guess there could be problems with focal now. May be some different packages. May be not.

Ideally would be better to have separate package list for each system, if maintaining support of several systems.