### PR TITLE
Adds initial Ubuntu 22.10 (Kinetic) support

### DIFF
--- a/.github/workflows/build-rescuezilla-iso.yml
+++ b/.github/workflows/build-rescuezilla-iso.yml
@@ -38,6 +38,11 @@ jobs:
         run: make docker-test
 
       - run: make docker-status
+      - name: Make Ubuntu 22.10 (Kinetic) ISO
+        run: make docker-kinetic
+      - run: sudo mv build/rescuezilla.amd64.kinetic.iso build/rescuezilla-${{github.ref_name}}-64bit.kinetic.iso
+
+      - run: make docker-status
       - name: Make Ubuntu 22.04 LTS (Jammy) ISO [LTS  = Long Term Support]
         run: make docker-jammy
       - run: sudo mv build/rescuezilla.amd64.jammy.iso build/rescuezilla-${{github.ref_name}}-64bit.jammy.iso

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ docker-status:
 
 # Start an interactive bash session for live debugging
 docker-bash:
-	docker exec --interactive --workdir=/home/rescuezilla/ builder.container /bin/bash
+	docker exec --interactive --tty --workdir=/home/rescuezilla/ builder.container /bin/bash
 
 docker-deb:
 	docker exec --interactive --workdir=/home/rescuezilla/ builder.container make deb

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.DEFAULT_GOAL := jammy
-.PHONY: all focal impish jammy i386 deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-latest partclone-utils partclone-nbd install test integration-test clean-build-dir clean clean-all
+.DEFAULT_GOAL := kinetic
+.PHONY: all focal impish jammy kinetic i386 deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-latest partclone-utils partclone-nbd install test integration-test clean-build-dir clean clean-all
 
 # FIXME: Properly specify the build artifacts to allow the GNU make to actually be smart about what gets built and when.
 # FIXME: This lack of specifying dependency graph means requires eg, `make focal` and `make impish` has to be done as separate invocations
@@ -37,6 +37,14 @@ jammy: ARCH=amd64
 jammy: CODENAME=jammy
 export ARCH CODENAME
 jammy: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-utils partclone-nbd $(buildscripts)
+	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) ./build.sh	
+
+kinetic: ARCH=amd64
+kinetic: CODENAME=kinetic
+export ARCH CODENAME
+# Not building partclone v0.3.20 yet as Kinetic uses 0.3.20+repack-1 already [1]
+# [1] https://packages.ubuntu.com/kinetic/partclone
+kinetic: deb sfdisk.v2.20.1.amd64 partclone-utils partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) ./build.sh	
 
 # ISO image based on Ubuntu 18.04 Bionic LTS (Long Term Support) 32bit (the last 32bit/i386 Ubuntu LTS release)
@@ -235,6 +243,9 @@ docker-bash:
 
 docker-deb:
 	docker exec --interactive --workdir=/home/rescuezilla/ builder.container make deb
+
+docker-kinetic:
+	docker exec --interactive --tty --workdir=/home/rescuezilla/ builder.container make kinetic
 
 docker-jammy:
 	docker exec --interactive --workdir=/home/rescuezilla/ builder.container make jammy

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ clean-all: clean-build-dir
 	$(info * Deleting cached apt-get indexes AND cached deb packages)
 	rm -rf pkg.cache/
 
+fix-permissions: clean
+  chown -R $(id -u):$(id -g) pkg.cache
+
 ### Helper targets to simplify running in Docker
 
 docker-build:

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -88,6 +88,8 @@ pkgs_specific_to_ubuntu2004_focal=("linux-generic-hwe-18.04"
                        "lupin-casper"
                        # Replaced by exfatprogs
                        "exfat-utils"
+                       # Removed since 22.10 Kinetic
+                       "plymouth-theme-ubuntu-logo"
 )
 
 pkgs_specific_to_ubuntu2110_impish=(
@@ -107,6 +109,8 @@ pkgs_specific_to_ubuntu2110_impish=(
                        "lupin-casper"
                        # Replaced by exfatprogs
                        "exfat-utils"
+                       # Removed since 22.10 Kinetic
+                       "plymouth-theme-ubuntu-logo"
 )
 
 pkgs_specific_to_ubuntu2204_jammy=(
@@ -125,6 +129,8 @@ pkgs_specific_to_ubuntu2204_jammy=(
                        "nbdkit"
                        # Replaces exfat-utils
                        "exfatprogs"
+                       # Removed since 22.10 Kinetic
+                       "plymouth-theme-ubuntu-logo"
 )
 
 # Languages on the system
@@ -184,7 +190,6 @@ common_pkgs=("discover"
              "network-manager-gnome"
              "plymouth-x11"
              "plymouth-label"
-             "plymouth-theme-ubuntu-logo"
              "pcmanfm"
              # PCManFM recommended packages to resolve paths like eg, smb://fileserver/johnsmith
              # TODO: Re-enable GVFS packages -- seems to cause issues around preventing refreshing partition

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -133,6 +133,25 @@ pkgs_specific_to_ubuntu2204_jammy=(
                        "plymouth-theme-ubuntu-logo"
 )
 
+pkgs_specific_to_ubuntu2210_kinetic=(
+                       "linux-generic"
+                       "xserver-xorg"
+                       "xserver-xorg-video-all"
+                       "xserver-xorg-video-intel"
+                       "xserver-xorg-video-qxl"
+                       "xserver-xorg-video-mga"
+                        # Packages which may assist users needing to do a GRUB repair (64-bit EFI)
+                       "shim-signed"
+                       "grub-efi-amd64-signed"
+                       "grub-efi-amd64-bin"
+                       "grub-efi-ia32-bin"
+                       # Dependency for partclone-utils' imagemount
+                       "nbdkit"
+                       # Replaces exfat-utils
+                       "exfatprogs"
+)
+
+
 # Languages on the system
 lang_codes=(
              "ar"
@@ -295,6 +314,8 @@ elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "impish" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2110_impish[@]}" "${common_pkgs[@]}")
 elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "jammy" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2204_jammy[@]}" "${common_pkgs[@]}")
+elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "kinetic" ]; then
+  apt_pkg_list=("${pkgs_specific_to_ubuntu2210_kinetic[@]}" "${common_pkgs[@]}")
 else
   echo "Warning: unknown CPU arch $ARCH or Ubuntu release codename $CODENAME"
   exit 1


### PR DESCRIPTION
Integrates into the build system Ubuntu 22.10 (Kinetic), including a bump in `debootstrap` submodule.

Note: the ISO image from this build has known issues that need to be fixed before public release.