### PR TITLE
Reenables building of Ubuntu 18.04 (Bionic) 32-bit (i386) support

### DIFF
--- a/.github/workflows/build-rescuezilla-iso.yml
+++ b/.github/workflows/build-rescuezilla-iso.yml
@@ -52,6 +52,11 @@ jobs:
         run: make docker-focal
       - run: sudo mv build/rescuezilla.amd64.focal.iso build/rescuezilla-${{github.ref_name}}-64bit.focal.iso
 
+      - run: make docker-status
+      - name: Make Ubuntu 18.04 LTS (Bionic) ISO (i386)
+        run: make docker-bionic-i386
+      - run: sudo mv build/rescuezilla.i386.bionic.iso build/rescuezilla-${{github.ref_name}}-32bit.bionic.iso
+
       - name: Create checksums for ISO images
         run: cd build && sudo ../src/scripts/create_iso_checksums.sh rescuezilla_${{env.DEB_VERSION}}-1_all.deb  rescuezilla-${{github.ref_name}}-*.iso
 

--- a/Makefile
+++ b/Makefile
@@ -253,3 +253,6 @@ docker-jammy:
 docker-focal:
 	docker exec --interactive --workdir=/home/rescuezilla/ builder.container make focal
 
+docker-bionic-i386:
+	docker exec --interactive --tty --workdir=/home/rescuezilla/ builder.container make bionic-i386
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := kinetic
-.PHONY: all focal impish jammy kinetic i386 deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-latest partclone-utils partclone-nbd install test integration-test clean-build-dir clean clean-all
+.PHONY: all focal impish jammy kinetic bionic-i386 deb sfdisk.v2.20.1.amd64 partclone.restore.v0.2.43.amd64 partclone-latest partclone-utils partclone-nbd install test integration-test clean-build-dir clean clean-all
 
 # FIXME: Properly specify the build artifacts to allow the GNU make to actually be smart about what gets built and when.
 # FIXME: This lack of specifying dependency graph means requires eg, `make focal` and `make impish` has to be done as separate invocations
@@ -48,10 +48,10 @@ kinetic: deb sfdisk.v2.20.1.amd64 partclone-utils partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) ./build.sh	
 
 # ISO image based on Ubuntu 18.04 Bionic LTS (Long Term Support) 32bit (the last 32bit/i386 Ubuntu LTS release)
-i386: ARCH=i386
-i386: CODENAME=bionic
+bionic-i386: ARCH=i386
+bionic-i386: CODENAME=bionic
 export ARCH CODENAME
-i386: deb $(buildscripts)
+bionic-i386: deb $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) ./build.sh
 
 deb: DEB_BUILD_DIR=$(abspath $(BASE_BUILD_DIRECTORY))/deb

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -306,18 +306,18 @@ if  [ "$IS_INTEGRATION_TEST" == "true" ]; then
     common_pkgs=("${common_pkgs[@]}" "openssh-server")
 fi
 
-if  [ "$ARCH" == "i386" ] && [ "$CODENAME" == "bionic" ]; then
+if    [ "$CODENAME" == "bionic" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu1804_bionic_32bit[@]}" "${common_pkgs[@]}")
-elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "focal" ]; then
+elif  [ "$CODENAME" == "focal" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2004_focal[@]}" "${common_pkgs[@]}")
-elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "impish" ]; then
+elif  [ "$CODENAME" == "impish" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2110_impish[@]}" "${common_pkgs[@]}")
-elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "jammy" ]; then
+elif  [ "$CODENAME" == "jammy" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2204_jammy[@]}" "${common_pkgs[@]}")
-elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "kinetic" ]; then
+elif  [ "$CODENAME" == "kinetic" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2210_kinetic[@]}" "${common_pkgs[@]}")
 else
-  echo "Warning: unknown CPU arch $ARCH or Ubuntu release codename $CODENAME"
+  echo "Warning: Unknown release codename $CODENAME"
   exit 1
 fi
 

--- a/chroot.steps.part.1.sh
+++ b/chroot.steps.part.1.sh
@@ -60,7 +60,7 @@ sed --in-place s/COMPRESS=gzip/COMPRESS=lz4/g /etc/initramfs-tools/initramfs.con
 # Hardware Enablement (HWE, also called LTS Enablement Stack) [1] [2]
 # https://wiki.ubuntu.com/Kernel/LTSEnablementStack
 # https://ubuntu.com/about/release-cycle
-pkgs_specific_to_32bit=("linux-generic-hwe-18.04"
+pkgs_specific_to_ubuntu1804_bionic_32bit=("linux-generic-hwe-18.04"
                         "xserver-xorg-hwe-18.04"
                         "xserver-xorg-video-all-hwe-18.04"
                         "xserver-xorg-video-intel-hwe-18.04"
@@ -306,8 +306,8 @@ if  [ "$IS_INTEGRATION_TEST" == "true" ]; then
     common_pkgs=("${common_pkgs[@]}" "openssh-server")
 fi
 
-if  [ "$ARCH" == "i386" ]; then
-  apt_pkg_list=("${pkgs_specific_to_32bit[@]}" "${common_pkgs[@]}")
+if  [ "$ARCH" == "i386" ] && [ "$CODENAME" == "bionic" ]; then
+  apt_pkg_list=("${pkgs_specific_to_ubuntu1804_bionic_32bit[@]}" "${common_pkgs[@]}")
 elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "focal" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2004_focal[@]}" "${common_pkgs[@]}")
 elif  [ "$ARCH" == "amd64" ] && [ "$CODENAME" == "impish" ]; then

--- a/src/apps/rescuezilla/debian/control
+++ b/src/apps/rescuezilla/debian/control
@@ -10,8 +10,8 @@ Vcs-Git: https://github.com/rescuezilla/rescuezilla.git
 
 Package: rescuezilla
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, smbclient, fsarchiver, partclone, pv, pigz, nmap, os-prober, gvfs, cifs-utils, smbclient, sshfs, sshpass, nfs-common, fsarchiver, file, xdg-utils, libnotify-bin, lshw, pciutils, yad, hdparm, pbzip2, lzop, pixz, plzip, lrzip, zstd, fatresize, archivemount, nbd-server, nbd-client, python3-whichcraft, python3-babel, clonezilla, lvm2, binutils, smartmontools, qemu-utils, nbdkit, efibootmgr
-Recommends: partimage, ecryptfs-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, smbclient, fsarchiver, partclone, pv, pigz, nmap, os-prober, gvfs, cifs-utils, smbclient, sshfs, sshpass, nfs-common, fsarchiver, file, xdg-utils, libnotify-bin, lshw, pciutils, yad, hdparm, pbzip2, lzop, pixz, plzip, lrzip, zstd, fatresize, archivemount, nbd-server, nbd-client, python3-whichcraft, python3-babel, clonezilla, lvm2, binutils, smartmontools, qemu-utils, efibootmgr
+Recommends: partimage, ecryptfs-utils, nbdkit
 Description: Graphical hard drive backup and restore
  Rescuezilla is an easy-to-use disk cloning and imaging application that's
  fully compatible with Clonezilla — the industry-standard trusted by tens

--- a/src/apps/rescuezilla/rescuezilla/usr/share/rescuezilla/rescuezilla.glade
+++ b/src/apps/rescuezilla/rescuezilla/usr/share/rescuezilla/rescuezilla.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="apart_gtk_icon">
     <property name="visible">True</property>
     <property name="can-focus">False</property>


### PR DESCRIPTION
Reintroduces a 32-bit (Intel i386) build, currently based on Ubuntu 18.04 (Bionic) after it was temporarily dropped in v2.0 (2020-10-14) 

Note: Partclone backwards compatibility is imperfect and 32-bit release uses old Ubuntu repository partclone version, not latest compiled version.

**Note: the ISO image from this build has known issues that need to be fixed before public release.**

[#232](https://github.com/rescuezilla/rescuezilla/issues/232)