### PR TITLE
Rescuezilla nf sv4

### DIFF
--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
@@ -138,10 +138,9 @@ class Handler:
         self.network_share_protocol_version_list.append(["3.0",     _("3.0 (Introduced in Windows 8,  Windows Server 2012)")])
         self.network_share_protocol_version_list.append(["3.0.2",   _("3.0.2 (Introduced in Windows 8.1, Windows Server 2012R2)")])
         self.network_share_protocol_version_list.append(["3.1.1",   _("3.1.1 (Introduced in Windows 10, Windows Server 2016)")])
-        
-        self.network_share_nfs_protocol_version_list = self.builder.get_object("network_share_nfs_protocol_version_list")
-        self.network_share_nfs_protocol_version_list.append(["3",     _("NFSv3")])
-        self.network_share_nfs_protocol_version_list.append(["4",     _("NFSv4")])
+        ## NFS ITEMS
+        self.network_share_protocol_version_list.append(["3",     _("NFSv3")])
+        self.network_share_protocol_version_list.append(["4",     _("NFSv4")])
 
         # Manage all network protocol UI widgets
         self.network_protocol_widget_dict = {

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
@@ -160,7 +160,6 @@ class Handler:
             'network_domain': {},
             'network_version_label': {},
             'network_version_combobox': {},
-            'network_version_nfs_combobox': {},
             'network_ssh_idfile': {},
             'network_ssh_idfile_box': {},
             'network_ssh_idfile_label': {},
@@ -176,7 +175,6 @@ class Handler:
                 self.network_protocol_widget_dict[prefix][mode] = object
             # Initialize the network version dropdown menu
             self.network_protocol_widget_dict['network_version_combobox'][mode].set_active(0)
-            self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_active(0)
 
         self.mount_partition_selection_treeselection_id_dict = {
             Mode.BACKUP: "backup_mount_partition_selection_treeselection",
@@ -1075,7 +1073,6 @@ class Handler:
                 self.network_protocol_widget_dict['network_version_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version"))
                 self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(True)
-                self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_box'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_port_label'][mode].set_visible(False)
@@ -1105,7 +1102,7 @@ class Handler:
                 self.network_protocol_widget_dict['network_port_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_port_label'][mode].set_text(_("Port"))
                 self.network_protocol_widget_dict['network_port'][mode].set_visible(True)
-        elif ( network_protocol_key == "NFSv3" or network_protocol_key == "NFSv4" ):
+        elif network_protocol_key == "NFS":
             for mode in NETWORK_UI_WIDGET_MODES:
                 self.network_protocol_widget_dict['network_server_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_server_label'][mode].set_text(_("Server") + ": ")
@@ -1121,7 +1118,6 @@ class Handler:
                 self.network_protocol_widget_dict['network_domain'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version"))
-                self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_box'][mode].set_visible(False)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
@@ -138,6 +138,11 @@ class Handler:
         self.network_share_protocol_version_list.append(["3.0",     _("3.0 (Introduced in Windows 8,  Windows Server 2012)")])
         self.network_share_protocol_version_list.append(["3.0.2",   _("3.0.2 (Introduced in Windows 8.1, Windows Server 2012R2)")])
         self.network_share_protocol_version_list.append(["3.1.1",   _("3.1.1 (Introduced in Windows 10, Windows Server 2016)")])
+        
+        self.network_share_nfs_protocol_version_list = self.builder.get_object("network_share_nfs_protocol_version_list")
+        self.network_share_nfs_protocol_version_list.append(["3",     _("NFSv3")])
+        self.network_share_nfs_protocol_version_list.append(["4",     _("NFSv4")])
+
         # Manage all network protocol UI widgets
         self.network_protocol_widget_dict = {
             'network_protocol_combobox': {},
@@ -156,6 +161,7 @@ class Handler:
             'network_domain': {},
             'network_version_label': {},
             'network_version_combobox': {},
+            'network_version_nfs_combobox': {},
             'network_ssh_idfile': {},
             'network_ssh_idfile_box': {},
             'network_ssh_idfile_label': {},
@@ -171,6 +177,7 @@ class Handler:
                 self.network_protocol_widget_dict[prefix][mode] = object
             # Initialize the network version dropdown menu
             self.network_protocol_widget_dict['network_version_combobox'][mode].set_active(0)
+            self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_active(0)
 
         self.mount_partition_selection_treeselection_id_dict = {
             Mode.BACKUP: "backup_mount_partition_selection_treeselection",
@@ -1069,6 +1076,7 @@ class Handler:
                 self.network_protocol_widget_dict['network_version_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version"))
                 self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(True)
+                self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_box'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_port_label'][mode].set_visible(False)
@@ -1098,7 +1106,7 @@ class Handler:
                 self.network_protocol_widget_dict['network_port_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_port_label'][mode].set_text(_("Port"))
                 self.network_protocol_widget_dict['network_port'][mode].set_visible(True)
-        elif network_protocol_key == "NFS":
+        elif ( network_protocol_key == "NFSv3" or network_protocol_key == "NFSv4" ):
             for mode in NETWORK_UI_WIDGET_MODES:
                 self.network_protocol_widget_dict['network_server_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_server_label'][mode].set_text(_("Server") + ": ")
@@ -1112,7 +1120,9 @@ class Handler:
                 self.network_protocol_widget_dict['network_password'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_domain_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_domain'][mode].set_visible(False)
-                self.network_protocol_widget_dict['network_version_label'][mode].set_visible(False)
+                self.network_protocol_widget_dict['network_version_label'][mode].set_visible(True)
+                self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version")
+                self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_box'][mode].set_visible(False)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
@@ -1118,7 +1118,7 @@ class Handler:
                 self.network_protocol_widget_dict['network_domain'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version"))
-                self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(False)
+                self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_ssh_idfile_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_box'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_port_label'][mode].set_visible(False)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
@@ -1121,7 +1121,7 @@ class Handler:
                 self.network_protocol_widget_dict['network_domain_label'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_domain'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_version_label'][mode].set_visible(True)
-                self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version")
+                self.network_protocol_widget_dict['network_version_label'][mode].set_text(_("Version"))
                 self.network_protocol_widget_dict['network_version_nfs_combobox'][mode].set_visible(True)
                 self.network_protocol_widget_dict['network_version_combobox'][mode].set_visible(False)
                 self.network_protocol_widget_dict['network_ssh_idfile_label'][mode].set_visible(False)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
@@ -268,7 +268,7 @@ class MountNetworkPath:
             if settings['nfs_version'] == "NFSv3":
                 mount_cmd_list = ["mount.nfs", server + ":" + exported_dir, settings['destination_path']]
                 mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv3: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
-            elif:
+            else:
                 mount_cmd_list = ["mount.nfs4", server + ":" + exported_dir, settings['destination_path']]
                 mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv4: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
 

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
@@ -42,6 +42,7 @@ class MountNetworkPath:
             'password': network_widget_dict["network_password"][mode].get_text(),
             'domain': network_widget_dict["network_domain"][mode].get_text().strip(),
             'version': Utility.get_combobox_key(network_widget_dict["network_version_combobox"][mode]),
+            'nfs_version' : Utility.get_combobox_key(network_widget_dict["network_version_nfs_combobox"][mode]),
             'ssh_idfile': network_widget_dict["network_ssh_idfile"][mode].get_text().strip(),
             'destination_path': destination_path,
             'port': network_widget_dict["network_port"][mode].get_text().strip(),
@@ -60,7 +61,9 @@ class MountNetworkPath:
             thread = threading.Thread(target=self._do_smb_mount_command, args=(settings,))
         elif network_protocol_key == "SSH":
             thread = threading.Thread(target=self._do_ssh_mount_command, args=(settings,))
-        elif network_protocol_key == "NFS":
+        elif network_protocol_key == "NFSv3":
+            thread = threading.Thread(target=self._do_nfs_mount_command, args=(settings,))
+        elif network_protocol_key == "NFSv4":
             thread = threading.Thread(target=self._do_nfs_mount_command, args=(settings,))
         else:
             raise ValueError("Unknown network protocol: " + network_protocol_key)
@@ -262,13 +265,13 @@ class MountNetworkPath:
                 GLib.idle_add(self.callback, False, "Must specify exported directory.")
                 return
 
-            try:
-                mount_cmd_list = ["mount.nfs4", server + ":" + exported_dir, settings['destination_path']]
-                mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv4: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
-            except:
+            if settings['nfs_version'] == "NFSv3":
                 mount_cmd_list = ["mount.nfs", server + ":" + exported_dir, settings['destination_path']]
                 mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv3: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
-                
+            elif:
+                mount_cmd_list = ["mount.nfs4", server + ":" + exported_dir, settings['destination_path']]
+                mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv4: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
+
             if mount_process.returncode != 0:
                 check_password_msg = _("Please ensure the server and exported path are correct, and try again.")
                 GLib.idle_add(self.please_wait_popup.destroy)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
@@ -60,9 +60,7 @@ class MountNetworkPath:
             thread = threading.Thread(target=self._do_smb_mount_command, args=(settings,))
         elif network_protocol_key == "SSH":
             thread = threading.Thread(target=self._do_ssh_mount_command, args=(settings,))
-        elif network_protocol_key == "NFSv3":
-            thread = threading.Thread(target=self._do_nfs_mount_command, args=(settings,))
-        elif network_protocol_key == "NFSv4":
+        elif network_protocol_key == "NFS":
             thread = threading.Thread(target=self._do_nfs_mount_command, args=(settings,))
         else:
             raise ValueError("Unknown network protocol: " + network_protocol_key)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/mount_network_path.py
@@ -262,8 +262,13 @@ class MountNetworkPath:
                 GLib.idle_add(self.callback, False, "Must specify exported directory.")
                 return
 
-            mount_cmd_list = ["mount.nfs", server + ":" + exported_dir, settings['destination_path']]
-            mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFS: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
+            try:
+                mount_cmd_list = ["mount.nfs4", server + ":" + exported_dir, settings['destination_path']]
+                mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv4: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
+            except:
+                mount_cmd_list = ["mount.nfs", server + ":" + exported_dir, settings['destination_path']]
+                mount_process, mount_flat_command_string, mount_failed_message = Utility.interruptable_run("Mounting network shared folder with NFSv3: ", mount_cmd_list, use_c_locale=False, is_shutdown_fn=self.is_stop_requested)
+                
             if mount_process.returncode != 0:
                 check_password_msg = _("Please ensure the server and exported path are correct, and try again.")
                 GLib.idle_add(self.please_wait_popup.destroy)


### PR DESCRIPTION
Hello All,

I noticed issue #354 regarding selection between NFSv3 and NFSv4 when mounting a network share.
I was unable to see any update to the code so have had a look myself.
Changes to 
handler.py and mount_network_path.py

The PR add NFSv3 and NFSv4 to the protocol version list as currently used by SMB ( see note below ) and based on the the NFS version selected runs a slightly different NFS mount command to switch between v3 and v4.

Lightly tested in VM running Rescuezilla to a physical NFS server checking via "mount -v" appears to show correct NFS version used during the mount process.

Regards.

