### PR TITLE
Fix various typos

### DIFF
--- a/docs/build_instructions/BUILD.ISO.IMAGE.md
+++ b/docs/build_instructions/BUILD.ISO.IMAGE.md
@@ -38,7 +38,7 @@ git submodule update --recursive
 # Optional: Build only the standalone deb packages without bothering with the live environment
 make deb
 
-# Optional: A Rescuezilla contributor suggests building on a ramdisk for increased build perfomance.
+# Optional: A Rescuezilla contributor suggests building on a ramdisk for increased build performance.
 # Most users may choose to skip the ramdisk steps due to high RAM requirements, and the increased
 # build complexity. It's possible to build with eg, `BASE_BUILD_DIRECTORY=/mnt/ramdisk make focal`
 # or copy the whole source folder into ramdisk. It's recommended you skip these steps if unsure.

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/backup_manager.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/backup_manager.py
@@ -41,7 +41,7 @@ from parser.sfdisk import Sfdisk
 from parser.swappt import Swappt
 from utility import Utility, _
 
-# Signals should automatically propogate to processes called with subprocess.run().
+# Signals should automatically propagate to processes called with subprocess.run().
 # TODO: This class uses 'subprocess.call', which provides exit code but not stdout/stderr. It would be
 # TODO: VERY useful to display stdout/stderr when the exit code is non-zero, like the RestoreManager does.
 class BackupManager:
@@ -360,7 +360,7 @@ class BackupManager:
 
             filepath = os.path.join(self.dest_dir, "Info-packages.txt")
             self.ui_manager.display_status(msg1=_("Saving: {file}").format(file=filepath), msg2="")
-            # Save Debian package informtion
+            # Save Debian package information
             if shutil.which("dpkg") is not None:
                 rescuezilla_package_list = ["rescuezilla", "partclone", "util-linux", "gdisk"]
                 with open(filepath, 'w') as filehandle:
@@ -598,7 +598,7 @@ class BackupManager:
 
         filepath = os.path.join(self.dest_dir, short_selected_device_node + "-chs.sf")
         self.ui_manager.display_status(msg1=_("Saving: {file}").format(file=filepath), msg2="")
-        process, flat_command_string, failed_message = Utility.run("Retreiving disk geometry with sfdisk ", ["sfdisk", "--show-geometry", self.selected_drive_key], use_c_locale=True, logger=self.logger)
+        process, flat_command_string, failed_message = Utility.run("Retrieving disk geometry with sfdisk ", ["sfdisk", "--show-geometry", self.selected_drive_key], use_c_locale=True, logger=self.logger)
         if process.returncode != 0:
             self.logger.write(failed_message)
             with self.summary_message_lock:

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/drive_query.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/drive_query.py
@@ -89,7 +89,7 @@ class DriveQuery:
                 drive = self.drive_state[drive_key]
                 with self._is_displaying_advanced_information_lock:
                     if self._is_displaying_advanced_information:
-                        # Display a advanced-user partition name eg, "nvme0n1". Users coming from Clonezilla will often
+                        # Display an advanced-user partition name eg, "nvme0n1". Users coming from Clonezilla will often
                         # like to know the device node.
                         human_friendly_drive_name = drive_key
                     else:
@@ -159,14 +159,14 @@ class DriveQuery:
                 for partition_key in self.drive_state[drive_key]['partitions'].keys():
                     with self._is_displaying_advanced_information_lock:
                         if self._is_displaying_advanced_information:
-                            # Display a advanced-user partition name eg, "nvme0n1p1".
+                            # Display an advanced-user partition name eg, "nvme0n1p1".
                             human_friendly_partition_name = partition_key
                         else:
                             if self.drive_state[drive_key]['type'] == 'loop' or self.drive_state[drive_key]['has_raid_member_filesystem']:
                                 # Don't display certain non-block device if user has chosen to hide them.
                                 # TODO: Evaluate other partition types to be hidden.
                                 continue
-                            # Display a advanced-user partition name eg, "#4".
+                            # Display an advanced-user partition name eg, "#4".
                             human_friendly_partition_name = "#" + str(index + 1)
                         flattened_partition_description = CombinedDriveState.flatten_partition_description(self.drive_state, drive_key, partition_key)
                     if 'size' in self.drive_state[drive_key]['partitions'][partition_key].keys():

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/handler.py
@@ -1499,7 +1499,7 @@ class Handler:
         if not self.image_explorer_manager.get_mounted_state() and not compression == "uncompressed":
             AreYouSureModalPopup(self.builder,
                              _(
-                                 "Reminder: Mounting large gzipped-compressed images WILL be UNUSABLY slow.\n\ngzip is the default compression format used by Clonezilla and Rescuezilla. If Rescuezilla doesn't cleanly unmount the image being explored a reboot may be required.\n\nIf you want the best experience with very large images with this BETA feature, it is highly recommeded you make an image WITHOUT COMPRESSION.\n\nAre you sure you want to continue?"),
+                                 "Reminder: Mounting large gzipped-compressed images WILL be UNUSABLY slow.\n\ngzip is the default compression format used by Clonezilla and Rescuezilla. If Rescuezilla doesn't cleanly unmount the image being explored a reboot may be required.\n\nIf you want the best experience with very large images with this BETA feature, it is highly recommended you make an image WITHOUT COMPRESSION.\n\nAre you sure you want to continue?"),
                              self._mount_partition_confirmation_callback)
         else:
             # Unmounting doesn't need an AreYouSure popup.

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/image_explorer_manager.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/image_explorer_manager.py
@@ -451,7 +451,7 @@ class ImageExplorerManager:
                 # concatenation is actually occurring.
                 #
                 # nbdkit's "--filter=" arguments can be used to decompress requested blocks on-the-fly in a single nbdkit
-                # invokation. However for flexibility with the older nbdkit version in Ubuntu 20.04 (see below),
+                # invocation. However for flexibility with the older nbdkit version in Ubuntu 20.04 (see below),
                 # and the limited number of compression filters even in recent nbdkit versions, Rescuezilla does this in
                 # two steps: joining the files is a different step to decompressing the files. This approach provides
                 # greater flexibility for alternative decompression utilities such as perhaps `archivemount` or AVFS.
@@ -597,7 +597,7 @@ class ImageExplorerManager:
 
                 print("Adding partclone-nbd process with pid " + str(partclone_nbd_process.pid) + " to queue")
                 self.partclone_nbd_process_queue.put(partclone_nbd_process)
-                # Sentinal value for successful partclone-nbd mount. partclone-nbd is launched with C locale env, so this
+                # Sentinel value for successful partclone-nbd mount. partclone-nbd is launched with C locale env, so this
                 # string will match even for non-English locales.
                 partclone_nbd_ready_msg = "[ INF ] Waiting for requests ..."
 

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/apart_gtk_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/apart_gtk_image.py
@@ -107,7 +107,7 @@ class ApartGtkImage:
         print("Last modified timestamp (max timestamp): " + self.last_modified_timestamp)
 
         self.size_bytes = estimated_num_byte
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
         self.is_needs_decryption = False
 

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/chs_utilities.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/chs_utilities.py
@@ -29,7 +29,7 @@ from logger import Logger
 #
 # For a great 5 minute introduction to CHS addressing, watch Nostalgia Nerd's YouTube video [1]. Cylinder-head-sector
 # addressing is largely obsolete after having been replaced by LBA (logical block addressing) in the mid-1990s.
-# However by many accounts NTFS filesytems need their own CHS metadata updated when an NTFS filesystem is moved
+# However by many accounts NTFS filesystems need their own CHS metadata updated when an NTFS filesystem is moved
 # between physical hard drives of different geometries. Updating the NTFS CHS information is required not only on
 # older drives and operating systems (such as an IDE drive running Windows Server 2003) but also modern drives and
 # operating systems (such as NVMe drives with Windows 10).
@@ -122,7 +122,7 @@ class ChsUtilities:
 
         # The --show-geometry call takes just a fraction of a second to run, so unlike Clonezilla always run it, because
         # that places both values in the log file which may be useful for debugging.
-        process, flat_command_string, failed_message = Utility.run("Retreiving disk geometry with sfdisk",
+        process, flat_command_string, failed_message = Utility.run("Retrieving disk geometry with sfdisk",
                                                                    ["sfdisk", "--show-geometry", long_device_node],
                                                                    use_c_locale=True, logger=logger)
         if process.returncode == 0:

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/clonezilla_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/clonezilla_image.py
@@ -345,7 +345,7 @@ class ClonezillaImage:
             if len(image_format_dict) == 0:
                 # Loop over all the volume groups (if any)
                 for vg_name in self.lvm_vg_dev_dict.keys():
-                    # TODO: Evalulate if there are Linux multipath device nodes that hold LVM Physical Volumes.
+                    # TODO: Evaluate if there are Linux multipath device nodes that hold LVM Physical Volumes.
                     # TODO: May need to adjust for multipath device node by replacing "/" with "-" for this node.
                     pv_short_device_node = re.sub('/dev/', '', self.lvm_vg_dev_dict[vg_name]['device_node'])
                     # Check if there is an associated LVM Physical Volume (PV) present
@@ -439,7 +439,7 @@ class ClonezillaImage:
             # size, so in that situation, summing the image sizes provides some kind of size estimate.
             self.size_bytes = total_size_estimate
 
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
 
         pp = pprint.PrettyPrinter(indent=4)

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/fogproject_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/fogproject_image.py
@@ -211,7 +211,7 @@ class FogProjectImage:
             # When the file doesn't exist, estimate drive capacity from sfdisk partition table backup
             last_partition_key, last_partition_final_byte = Sfdisk.get_highest_offset_partition(self.normalized_sfdisk_dict)
             self.size_bytes = last_partition_final_byte
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
         self.is_needs_decryption = False
 

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/foxclone_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/foxclone_image.py
@@ -154,7 +154,7 @@ class FoxcloneImage:
         # Foxclone doesn't keep track of the drive capacity, so estimate it from sfdisk partition table backup
         last_partition_key, last_partition_final_byte = Sfdisk.get_highest_offset_partition(self.normalized_sfdisk_dict)
         self.size_bytes = last_partition_final_byte
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
 
         for image_format_dict_key in self.image_format_dict_dict.keys():

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/fsarchiver_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/fsarchiver_image.py
@@ -82,7 +82,7 @@ class FsArchiverImage:
         else:
             self.last_modified_timestamp = format_datetime(datetime.fromtimestamp((os.stat(absolute_fsarchiver_fsa_path).st_mtime)))
             self.size_bytes = Utility.count_total_size_of_files_on_disk([absolute_fsarchiver_fsa_path], "unknown")
-            # Covert size in bytes to KB/MB/GB/TB as relevant
+            # Convert size in bytes to KB/MB/GB/TB as relevant
             self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
             if "password" in process.stderr:
                 print("Image is encrypted.")
@@ -104,7 +104,7 @@ class FsArchiverImage:
         self.size_bytes = 0
         for fs_key in self.fsa_dict['filesystems'].keys():
             self.size_bytes += self.fsa_dict['filesystems'][fs_key]['size_bytes']
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
 
     def has_partition_table(self):

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/metadata_only_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/metadata_only_image.py
@@ -114,7 +114,7 @@ class MetadataOnlyImage:
         process, flat_command_string, fail_description = Utility.run("lsblk", lsblk_cmd_list, use_c_locale=True)
         lsblk_json_dict = json.loads(process.stdout)
 
-        # blkid is called in DriveQuery and without arugments it prints information about all *partitions* in the system
+        # blkid is called in DriveQuery and without arguments it prints information about all *partitions* in the system
         # (eg, /dev/sda1, /dev/sda2), but not th base device. But with an argument, it only prints out the base device.
         # But globbing using an wildcard match prints out the base device *and* the partitions. Not ideal, but it works.
         partition_device_glob_list = glob.glob(self.long_device_node + "*")
@@ -151,7 +151,7 @@ class MetadataOnlyImage:
         self.size_bytes = last_partition_final_byte
         if self.size_bytes == 0:
             self.size_bytes = self.parted_dict['capacity']
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
 
     # The BackupManager, needs partition information (filesystems etc) in certain structure. Clonezilla combines

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/redobackup_legacy_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/redobackup_legacy_image.py
@@ -93,7 +93,7 @@ class RedoBackupLegacyImage:
 
         self.size_bytes = int(Utility.read_file_into_string(os.path.join(dirname, prefix + ".size").strip()))
         print("Size: " + str(self.size_bytes))
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
 
         self._mbr_absolute_path = os.path.join(dirname, prefix + ".mbr")

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/redorescue_image.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/parser/redorescue_image.py
@@ -97,7 +97,7 @@ class RedoRescueImage:
             self.warning_dict[enduser_filename] = Sfdisk.get_empty_sfdisk_msg()
 
         self.size_bytes = self.redo_dict['drive_bytes']
-        # Covert size in bytes to KB/MB/GB/TB as relevant
+        # Convert size in bytes to KB/MB/GB/TB as relevant
         self.enduser_readable_size = Utility.human_readable_filesize(int(self.size_bytes))
 
         self.image_format_dict_dict = collections.OrderedDict([])

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/partitions_to_restore.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/partitions_to_restore.py
@@ -128,7 +128,7 @@ class PartitionsToRestore:
                       message=msg)
 
     # Starts LVM and umounts all relevant logical volumes
-    # FIXME: Similar code is is duplicated elsewhere in the codebase.
+    # FIXME: Similar code is duplicated elsewhere in the codebase.
     def _scan_and_unmount_existing_lvm(self, dest_partitions, is_overwriting_partition_table):
         with self.lvm_lv_path_lock:
             self.lvm_lv_path_list.clear()
@@ -401,7 +401,7 @@ class PartitionsToRestore:
                 num_combo_box_entries += 1
 
         # If there is no partitions on the destination disk, provide the option to remap the partitions to the whole
-        # destination disk. If the source image doesn't have a partition table, also want to be able to remap partitons
+        # destination disk. If the source image doesn't have a partition table, also want to be able to remap partitions
         # to the destination disk. Finally, if the destination disk already has a filesystem directly on disk then
         # that would have already been handled above and there's no need to add a new entry to the combobox.
         if (num_combo_box_entries == 0 or not self.selected_image.has_partition_table()) and not is_destination_partition_target_drive:

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/restore_manager.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/restore_manager.py
@@ -775,7 +775,7 @@ class RestoreManager:
 
                 dest_part = self.restore_mapping_dict[image_key]
                 if self.image.image_format_dict_dict[image_key]['is_lvm_logical_volume']:
-                    # Erase the filesytem header when it exists
+                    # Erase the filesystem header when it exists
                     is_success, failed_message = self.clean_filesystem_header_in_partition(dest_part['dest_key'])
                     if not is_success:
                         # Error callback handled in the function
@@ -1112,7 +1112,7 @@ class RestoreManager:
                 if process.returncode == 0:
                     message = "Successfully removed any udev MAC address records"
                     self.logger.write(message + "\n")
-                    # Not displaying this to users because it wil lbe confusing for end-users.
+                    # Not displaying this to users because it will be confusing for end-users.
             else:
                 message = "Not removing udev MAC address records: Unable to find ocs-tux-postprocess. Is Clonezilla installed?"
                 self.logger.write(message + "\n")

--- a/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/utility.py
+++ b/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla/utility.py
@@ -844,7 +844,7 @@ class Utility:
             return False, message
 
         size_in_bytes=""
-        # Growing FAT filesystems require quering partition size which other filesystems don't.
+        # Growing FAT filesystems require querying partition size which other filesystems don't.
         if filesystem == "vfat" or filesystem == "fat16" or filesystem == "fat32":
             is_success, output = Utility.query_partition_size_bytes(long_device_node)
             if not is_success:
@@ -890,7 +890,7 @@ class Utility:
                     if process.returncode != 0:
                         return False, failed_message
                 if len(resize_cmd_list) > 0:
-                    resize_process, resize_flat_command_string, resize_failed_message = Utility.run("Growing filesytem " + combined_identifier, resize_cmd_list, use_c_locale=False, logger=logger)
+                    resize_process, resize_flat_command_string, resize_failed_message = Utility.run("Growing filesystem " + combined_identifier, resize_cmd_list, use_c_locale=False, logger=logger)
                     # Always umount, even on resize failure
                     if len(mount_cmd_list) > 0:
                         umount_process, umount_flat_command_string, umount_failed_message = Utility.run("Umounting " + combined_identifier, ["umount", long_device_node], use_c_locale=False, logger=logger)

--- a/src/apps/rescuezilla/rescuezilla/usr/sbin/rescuezilla
+++ b/src/apps/rescuezilla/rescuezilla/usr/sbin/rescuezilla
@@ -191,7 +191,7 @@ if test "x$HAVE_SYSTEMCTL" = "xyes"; then
       | egrep -v '^(dev-hugepages|dev-mqueue|proc-sys-fs-binfmt_misc|run-user-.*-gvfs|sys-fs-fuse-connections|sys-kernel-config|sys-kernel-debug)'`
     systemctl --runtime mask --quiet -- $MOUNTLIST
 
-    # The Rescuezilla live environment has a user named 'ubuntu' with user ID 999. The existance of a GNOME Virtual Filesystem (GVFS) mount causes
+    # The Rescuezilla live environment has a user named 'ubuntu' with user ID 999. The existence of a GNOME Virtual Filesystem (GVFS) mount causes
     # Rescuezilla to fail on some restore operations, due to gvfs preventing the partition table from refreshing.
     UBUNTU_USER_MOUNTLIST=$( run_systemctl_as_ubuntu "systemctl --user list-units --full --all -t mount --no-legend \
       | grep -v masked | cut -f1 -d' ' \
@@ -231,7 +231,7 @@ for rule in $UDEV_TEMP_MDADM_RULES; do
 done
 
 #
-#  Use udisks2-inhibit if udisks2-inhibit exists and deamon running.
+#  Use udisks2-inhibit if udisks2-inhibit exists and daemon running.
 #  Else use both udisks and hal-lock for invocation if both binaries exist and both
 #  daemons are running.
 #  Else use udisks if binary exists and daemon is running.

--- a/src/integration-test/integration_test.py
+++ b/src/integration-test/integration_test.py
@@ -483,7 +483,7 @@ def handle_command(args):
     else:
         machine_key_list = args.vm
         if args.hd == "all":
-            # If a list of VMs has been specified, carefully gather all hard drives assocated with those machines
+            # If a list of VMs has been specified, carefully gather all hard drives associated with those machines
             hd_set = set()
             for vm_key in machine_key_list:
                 for hd_key in MACHINE_DICT[vm_key]['hd_list']:

--- a/src/integration-test/scripts/install_windows_query_tcp_server.bat
+++ b/src/integration-test/scripts/install_windows_query_tcp_server.bat
@@ -17,7 +17,7 @@ curl "https://nmap.org/dist/nmap-7.92-setup.exe" -o "C:\nmap-7.92-setup.exe"
 :: Download Non-Sucking Service Manager (because Windows service manager can't run Batch files)
 curl "https://nssm.cc/release/nssm-2.24.zip" -o C:\nssm-2.24.zip
 
-echo "Runing the nmap installer. Make sure to install Nmap core files and Ncat"
+echo "Running the nmap installer. Make sure to install Nmap core files and Ncat"
 :: There does not appear to be a /s (silent) install option, so install it manually.
 C:\nmap-7.92-setup.exe
 

--- a/src/livecd/chroot/etc/rc.local
+++ b/src/livecd/chroot/etc/rc.local
@@ -26,7 +26,7 @@ chown -R ubuntu:ubuntu /home/ubuntu
 swapoff --all
 
 # When Rescuezilla is booted using "toram" kernel option, the /isodevice path is
-# automatically mounted for some reason. But after teh boot with "toram" is complete
+# automatically mounted for some reason. But after the boot with "toram" is complete
 # this path can be safely unmounted.
 #
 # [1] https://github.com/rescuezilla/rescuezilla/wiki/Installing-Rescuezilla-as-a-rescue-partition


### PR DESCRIPTION
Fixes various user-facing and non-user-facing typos. 

Found via `codespell -q 3 -S "*.po,*.desktop,CHANGELOG,./CHANGELOG.md" -L preprepared`