### PR TITLE
Initial ARM64 ISO build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ FROM ubuntu:${CODENAME}
 # Define the Ubuntu code name again because Docker clears the argument after the FROM command.
 ARG CODENAME=noble
 
+# Detect the running container architecture (can be overridden via --build-arg)
+ARG RUNNING_CONTAINER_ARCH
+RUN RUNNING_CONTAINER_ARCH="${RUNNING_CONTAINER_ARCH:-$(dpkg --print-architecture)}"
+
 # Copy the apt repository mirror list into the Docker image.
 # 
 # For increased transfer rates, consider selecting a mirror geographically
@@ -22,7 +26,19 @@ COPY src/livecd/chroot/etc/apt/sources.list /etc/apt/sources.list
 # Copy the apt-preferences file to ensure backports and proposed repositories are never automatically selected.
 COPY "src/livecd/chroot/etc/apt/preferences.d/89_CODENAME_SUBSTITUTE-backports_default" "/etc/apt/preferences.d/89_$CODENAME-backports_default"
 COPY "src/livecd/chroot/etc/apt/preferences.d/90_CODENAME_SUBSTITUTE-proposed_default" "/etc/apt/preferences.d/90_$CODENAME-proposed_default"
+
+RUN RUNNING_CONTAINER_ARCH="${RUNNING_CONTAINER_ARCH:-$(dpkg --print-architecture)}" \
+; if [ "$RUNNING_CONTAINER_ARCH" = "amd64" ] || [ "$RUNNING_CONTAINER_ARCH" = "i386" ]; then \
+    URL="http://archive.ubuntu.com/ubuntu" \
+    ; sed --in-place "s*URL_SUBSTITUTE*$URL*g" "/etc/apt/sources.list" \
+; else \
+    URL="http://ports.ubuntu.com/ubuntu-ports/ubuntu-ports" \
+    ; sed --in-place "s*URL_SUBSTITUTE*$URL*g" "/etc/apt/sources.list" \
+; fi
+
+
 RUN sed --in-place "s*CODENAME_SUBSTITUTE*$CODENAME*g" "/etc/apt/sources.list"
+RUN cat /etc/apt/sources.list
 RUN sed --in-place "s*CODENAME_SUBSTITUTE*$CODENAME*g" /etc/apt/preferences.d/89_${CODENAME}-backports_default
 RUN sed --in-place "s*CODENAME_SUBSTITUTE*$CODENAME*g" /etc/apt/preferences.d/90_${CODENAME}-proposed_default
 
@@ -35,9 +51,10 @@ RUN apt-get update
 
 RUN apt-get install --yes \
                           # Install required dependencies for the build
-                          make rsync sudo debootstrap squashfs-tools xorriso memtest86+ git git-lfs gettext \
+                          make rsync sudo debootstrap squashfs-tools xorriso \
+                          git git-lfs gettext \
                           dosfstools mtools checkinstall cmake time \
-                          shim-signed grub-efi-amd64-signed grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin \
+                          shim-signed \
                           devscripts debhelper ccache \
                           # Dependencies for "sfdisk" and "partclone.restore" build.
                           libtool-bin gawk pkg-config comerr-dev docbook-xsl e2fslibs-dev fuse3 \
@@ -52,6 +69,21 @@ RUN apt-get install --yes \
                           curl \
                           # Install optional dependencies for quality-of-life when debugging
                           tmux vim
+
+# Install key packages that are only available for containers built on amd64.
+RUN RUNNING_CONTAINER_ARCH="${RUNNING_CONTAINER_ARCH:-$(dpkg --print-architecture)}" \
+; if [ "$RUNNING_CONTAINER_ARCH" = "amd64" ]; then \
+    apt-get install --yes \
+        memtest86+ \
+        grub-efi-amd64-signed grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin \
+; fi
+
+# Install key packages that are only available for containers built on arm64.
+RUN RUNNING_CONTAINER_ARCH="${RUNNING_CONTAINER_ARCH:-$(dpkg --print-architecture)}" \
+; if [ "$RUNNING_CONTAINER_ARCH" = "arm64" ]; then \
+    apt-get install --yes \
+        grub-efi-arm64 grub-efi-arm64-bin \
+; fi
 
 # Install Astral's Python tooling, as on Ubuntu Noble it's not available in the default package repositories.
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 	oracular \
 	plucky \
 	noble \
+	noble-arm64 \
 	bionic-i386 \
 	deb \
 	sfdisk.v2.20.1.amd64 \
@@ -66,6 +67,13 @@ plucky: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
 noble: CODENAME=noble
 export ARCH CODENAME
 noble: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
+	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) /usr/bin/time ./src/scripts/build.sh	
+
+# Test
+noble-arm64: CODENAME=noble
+noble-arm64: ARCH=arm64
+export ARCH CODENAME
+noble-arm64: deb partclone-latest partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) /usr/bin/time ./src/scripts/build.sh	
 
 # ISO image based on Ubuntu 18.04 Bionic LTS (Long Term Support) 32bit (the last 32bit/i386 Ubuntu LTS release)

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ include src/scripts/mk/python.mk
 # FIXME: Somewhat related -- Improve build environment's ability to compile software (https://github.com/rescuezilla/rescuezilla/issues/150)
 
 BASE_BUILD_DIRECTORY ?= $(shell pwd)/build
+ARCH ?= amd64
 
 # Set shell to bash, so can use 'pipefail' to cause Make to exit when certain commands below (that pipe into tee) fails
 SHELL=/bin/bash
@@ -40,25 +41,21 @@ all: focal
 buildscripts = src/scripts/build.sh src/scripts/chroot-steps-part-1.sh src/scripts/chroot-steps-part-2.sh
 
 # ISO image based on Ubuntu 20.04 Focal LTS (Long Term Support) 64bit
-focal: ARCH=amd64
 focal: CODENAME=focal
 export ARCH CODENAME
 focal: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) /usr/bin/time ./src/scripts/build.sh
 
-jammy: ARCH=amd64
 jammy: CODENAME=jammy
 export ARCH CODENAME
 jammy: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) /usr/bin/time ./src/scripts/build.sh	
 
-oracular: ARCH=amd64
 oracular: CODENAME=oracular
 export ARCH CODENAME
 oracular: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
 	BASE_BUILD_DIRECTORY=$(BASE_BUILD_DIRECTORY) /usr/bin/time ./src/scripts/build.sh	
 
-plucky: ARCH=amd64
 plucky: CODENAME=plucky
 export ARCH CODENAME
 plucky: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
@@ -66,7 +63,6 @@ plucky: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)
 
 # Note: Ubuntu 24.04 (Long Term Support) won't be released until around April 2024, as per the version string
 # Kept here as the unreleased version can be built and used as a kind of pre-alpha release
-noble: ARCH=amd64
 noble: CODENAME=noble
 export ARCH CODENAME
 noble: deb sfdisk.v2.20.1.amd64 partclone-latest partclone-nbd $(buildscripts)

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ partclone-latest:
 	cd $(PARTCLONE_LATEST_BUILD_DIR) && make
 	# Create deb package from a standard Makefile's `make install` using the checkinstall tool (for cleaner uninstall)
 	cd $(PARTCLONE_LATEST_BUILD_DIR) && checkinstall --install=no --pkgname partclone --pkgversion $(PARTCLONE_PKG_VERSION) --pkgrelease 1 --maintainer 'rescuezilla@gmail.com' -D --default  make install
-	mv $(PARTCLONE_LATEST_BUILD_DIR)/partclone_$(PARTCLONE_PKG_VERSION)-1_amd64.deb $(AMD64_BUILD_DIR)/chroot/
+	mv $(PARTCLONE_LATEST_BUILD_DIR)/partclone_$(PARTCLONE_PKG_VERSION)-1_$(ARCH).deb $(AMD64_BUILD_DIR)/chroot/
 
 # Builds partclone-utils, which contains some very useful utilities for working with partclone images.
 partclone-utils: SRC_DIR=$(shell pwd)/src/third-party/partclone-utils
@@ -162,7 +162,7 @@ partclone-utils:
 	cd $(PARTCLONE_UTILS_BUILD_DIR) && ./configure
 	# Create deb package from a standard Makefile's `make install` using the checkinstall tool (for cleaner uninstall)
 	cd $(PARTCLONE_UTILS_BUILD_DIR) && checkinstall --install=no --pkgname partclone-utils --pkgversion 0.4.2 --pkgrelease 1 --maintainer 'rescuezilla@gmail.com' -D --default  make install
-	mv $(PARTCLONE_UTILS_BUILD_DIR)/partclone-utils_0.4.2-1_amd64.deb $(AMD64_BUILD_DIR)/chroot/
+	mv $(PARTCLONE_UTILS_BUILD_DIR)/partclone-utils_0.4.2-1_$(ARCH).deb $(AMD64_BUILD_DIR)/chroot/
 
 # Builds partclone-nbd, a competitor project to partclone-utils that's also able to mount partclone images.
 partclone-nbd: SRC_DIR=$(shell pwd)/src/third-party/partclone-nbd
@@ -175,7 +175,7 @@ partclone-nbd:
 	# Compile and package DEB. Override the user-managed /opt target installation directory with /usr/local since
 	# build scripts constitutes the system administrator of the operating system being constructed so /opt is less appropriate
 	cd $(PARTCLONE_NBD_BUILD_DIR) && cpack -D CPACK_PACKAGING_INSTALL_PREFIX="/usr/local" -G DEB
-	mv $(PARTCLONE_NBD_BUILD_DIR)/_packages/partclone-nbd_0.0.4_amd64.deb $(AMD64_BUILD_DIR)/chroot/
+	mv $(PARTCLONE_NBD_BUILD_DIR)/_packages/partclone-nbd_0.0.4_$(ARCH).deb $(AMD64_BUILD_DIR)/chroot/
 
 clean-build-dir:
 	$(info * Unmounting chroot bind mounts)
@@ -203,7 +203,7 @@ install: AMD64_BUILD_DIR=$(BASE_BUILD_DIRECTORY)/$(CODENAME).$(ARCH)
 install: PARTCLONE_NBD_BUILD_DIR=$(AMD64_BUILD_DIR)/partclone-nbd
 install: DEB_BUILD_DIR=$(BASE_BUILD_DIRECTORY)/deb
 install: partclone-nbd deb
-	DEBIAN_FRONTEND=noninteractive gdebi --non-interactive $(AMD64_BUILD_DIR)/chroot/partclone-nbd_0.0.3-1_amd64.deb
+	DEBIAN_FRONTEND=noninteractive gdebi --non-interactive $(AMD64_BUILD_DIR)/chroot/partclone-nbd_0.0.3-1_$(ARCH).deb
 	DEBIAN_FRONTEND=noninteractive gdebi --non-interactive $(DEB_BUILD_DIR)/../rescuezilla_*.deb
 
 test: RESCUEZILLA_TEST_DIR=$(shell pwd)/src/apps/rescuezilla/rescuezilla/usr/lib/python3/dist-packages/rescuezilla

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -336,10 +336,13 @@ fi
 mkdir -p image/memtest
 # The memtest binaries are copied in from the host system (ie, the Docker build container)
 # TODO(#540): Support 64-bit and EFI memtest packages
-cp /boot/memtest86+ia32.bin image/memtest/
-if [[ $? -ne 0 ]]; then
-    echo "Error: Failed to copy memtest86+ binary from host system."
-    exit 1
+if [ "$ARCH" == "amd64" ] || [ "$ARCH" == "i386" ]; then
+    mkdir -p image/memtest
+    cp /boot/memtest86+ia32.bin image/memtest/
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to copy memtest86+ binary from host system."
+        exit 1
+    fi
 fi
 
 # Create manifest

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -317,21 +317,23 @@ umount -lf chroot/dev/
 rm chroot/root/.bash_history
 rm chroot/chroot-steps-part-1.sh chroot/chroot-steps-part-2.sh
 
-mkdir -p image/casper image/memtest
-cp chroot/boot/vmlinuz-*-generic image/casper/vmlinuz
+mkdir -p image/casper
+# The vmlinuz is a symlink to the exact kernel version, so no need to use the versioned glob.
+cp chroot/boot/vmlinuz image/casper/vmlinuz
 if [[ $? -ne 0 ]]; then
     echo "Error: Failed to copy vmlinuz image."
     exit 1
 fi
-# Ensures compressed Linux kernel image is readable during the MD5 checksum at boot
 chmod 644 image/casper/vmlinuz
 
-cp chroot/boot/initrd.img-*-generic image/casper/initrd.lz
+# The initrd.img is a symlink to the exact initrd version, so no need to use the versioned glob.
+cp chroot/boot/initrd.img image/casper/initrd.lz
 if [[ $? -ne 0 ]]; then
     echo "Error: Failed to copy initrd image."
     exit 1
 fi
 
+mkdir -p image/memtest
 # The memtest binaries are copied in from the host system (ie, the Docker build container)
 # TODO(#540): Support 64-bit and EFI memtest packages
 cp /boot/memtest86+ia32.bin image/memtest/

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -389,7 +389,7 @@ rm -rf image/casper/filesystem.squashfs "$RESCUEZILLA_ISO_FILENAME"
 
 echo "Compressing squashfs using zstandard (rather than default gzip)."
 if  [ "$IS_INTEGRATION_TEST" == "true" ]; then
-    echo "Using lowest possible compression level of 1 to speed up compression for debug builds." 
+    echo "Using lowest possible compression level of 1 to speed up compression for debug builds."
     COMPRESSION_LEVEL=1
 else
     echo "Using max compression level of 19. The compression time is greatly increased, but the decompression time "

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -406,16 +406,25 @@ mkdir --parents "$BUILD_DIRECTORY/image/EFI/BOOT/"
 # Add the Microsoft-signed EFI Secure Boot shim for AMD64 to the EFI System Partition (ESP). Also renames the shim to be the default bootloader
 # so is automatically launched when the UEFI firmware launches this device. Given the target Linux kernel is Canonical-signed, for Secure Boot
 # to work the shim needs to be from Ubuntu's `shim-signed` package (which trusts Canonical keys), see below.
-cp /usr/lib/shim/shimx64.efi.signed "$BUILD_DIRECTORY/image/EFI/BOOT/BOOTx64.EFI"
-# Add the Canonical-signed GRUB EFI loader executable for AMD64 to the ESP. This is a small EFI executable which is launched by the shim. It reads
-# the nearby grub.cfg and uses it to access the squashfs-compressed filesystem to read another grub.cfg access other GRUB modules etc.
-#
-# Given the target Linux kernel is Canonical-signed, for Secure Boot to work the shim needs to be from Ubuntu's `grub-efi-amd64-signed package`
-# (which trusts Canonical keys), it will not verify with Debian's `grub-efi-amd64-signed` package (as it trusts Debian's keys, so cannot verify
-# a Canonical-signed kernel)
-cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$BUILD_DIRECTORY/image/EFI/BOOT/grubx64.efi"
-# Deploy the GRUB AMD64 support files, including loadable modules
-cp -r /usr/lib/grub/x86_64-efi "$BUILD_DIRECTORY/image/boot/grub/"
+if [ "$ARCH" == "amd64" ] || [ "$ARCH" == "i386" ]; then
+    cp /usr/lib/shim/shimx64.efi.signed "$BUILD_DIRECTORY/image/EFI/BOOT/BOOTx64.EFI"
+    # Add the Canonical-signed GRUB EFI loader executable for AMD64 to the ESP. This is a small EFI executable which is launched by the shim. It reads
+    # the nearby grub.cfg and uses it to access the squashfs-compressed filesystem to read another grub.cfg access other GRUB modules etc.
+    #
+    # Given the target Linux kernel is Canonical-signed, for Secure Boot to work the shim needs to be from Ubuntu's `grub-efi-amd64-signed package`
+    # (which trusts Canonical keys), it will not verify with Debian's `grub-efi-amd64-signed` package (as it trusts Debian's keys, so cannot verify
+    # a Canonical-signed kernel)
+    cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed "$BUILD_DIRECTORY/image/EFI/BOOT/grubx64.efi"
+    # Deploy the GRUB AMD64 support files, including loadable modules
+    cp -r /usr/lib/grub/x86_64-efi "$BUILD_DIRECTORY/image/boot/grub/"
+elif [[ "$ARCH" == "arm64" ]]; then
+    cp /usr/lib/shim/shimaa64.efi.signed "$BUILD_DIRECTORY/image/EFI/BOOT/BOOTAA64.EFI"
+    cp /usr/lib/grub/arm64-efi-signed/grubaa64.efi.signed "$BUILD_DIRECTORY/image/EFI/BOOT/grubaa64.efi"
+    cp -r /usr/lib/grub/arm64-efi "$BUILD_DIRECTORY/image/boot/grub/"
+else
+    echo "Unsupported ARCH for EFI bootloader packaging: $ARCH"
+    exit 1
+fi
 
 mkdir "$BUILD_DIRECTORY/image/boot/grub/fonts"
 # Deploy unicode font
@@ -424,11 +433,13 @@ cp /usr/share/grub/unicode.pf2 "$BUILD_DIRECTORY/image/boot/grub/fonts"
 # Copy the GRUB EFI loader executable for i386 (there is no signed GRUB EFI versions available for i386). Multiple EFI bootloaders for different
 # CPU architectures can safely co-exist (given the different filenames), with the EFI firmware launching the correctly named executable.
 # Also, Bay Trail Intel Atom CPUs apparently have 64-bit CPUs with 32-bit UEFI, so having both i386 and amd64 executable on an amd64 ISO seems good.
-cp /usr/lib/grub/i386-efi/monolithic/grubia32.efi "$BUILD_DIRECTORY/image/EFI/BOOT/BOOTIA32.EFI"
-# Deploy i386 GRUB EFI support files, including loadable modules
-cp -r /usr/lib/grub/i386-efi "$BUILD_DIRECTORY/image/boot/grub/"
-# Deploy i386 GRUB non-EFI support files to support El Torito optical disk boot on both i386 and amd64 systems using either ISO architecture variant
-cp -r /usr/lib/grub/i386-pc "$BUILD_DIRECTORY/image/boot/grub/"
+if [[ "$ARCH" == "amd64" ]]; then
+    cp /usr/lib/grub/i386-efi/monolithic/grubia32.efi "$BUILD_DIRECTORY/image/EFI/BOOT/BOOTIA32.EFI"
+    # Deploy i386 GRUB EFI support files, including loadable modules
+    cp -r /usr/lib/grub/i386-efi "$BUILD_DIRECTORY/image/boot/grub/"
+    # Deploy i386 GRUB non-EFI support files to support El Torito optical disk boot on both i386 and amd64 systems using either ISO architecture variant
+    cp -r /usr/lib/grub/i386-pc "$BUILD_DIRECTORY/image/boot/grub/"
+fi
 
 # Create an EFI System Partition (ESP), by first creating a small blank file then formatting a file as a FAT16 filesystem.
 #
@@ -471,10 +482,12 @@ fi
 
 # Generate the i386 CD-ROM/USB drive El Torito boot image (used for both AMD64/i386 CD-ROM boot) and save it in the ISO image filesystem
 # TODO: Reduce number of GRUB modules to the absolute bare minimum.
-grub-mkimage --format i386-pc-eltorito --output "$BUILD_DIRECTORY/image/boot/grub/grub.eltorito.bootstrap.img" --compression auto --prefix /boot/grub boot linux search normal configfile part_gpt fat iso9660 biosdisk test keystatus gfxmenu regexp probe efiemu all_video gfxterm font echo read ls cat png jpeg halt reboot part_msdos biosdisk
-if [[ $? -ne 0 ]]; then
-    echo "Error: Failed to create the GRUB bootstrap image required for El Torito CD-ROM boot."
-    exit 1
+if [ "$ARCH" == "amd64" ] || [ "$ARCH" == "i386" ]; then
+    grub-mkimage --format i386-pc-eltorito --output "$BUILD_DIRECTORY/image/boot/grub/grub.eltorito.bootstrap.img" --compression auto --prefix /boot/grub boot linux search normal configfile part_gpt fat iso9660 biosdisk test keystatus gfxmenu regexp probe efiemu all_video gfxterm font echo read ls cat png jpeg halt reboot part_msdos biosdisk
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to create the GRUB bootstrap image required for El Torito CD-ROM boot."
+        exit 1
+    fi
 fi
 
 # Pack the 'image' subdirectory to become a bootable ISO 9660 image using xorrisofs (which is "xorriso" but using the mkisofs/genisoimage
@@ -516,50 +529,59 @@ xorrisofs_args=(
                -joliet
                # "Allow up to 31 characters in ISO file names"
                -full-iso9660-filenames
-               # Installs GRUB2 into the Master Boot Record (MBR) present within the ISO9660 "System Area", in order to support for disk boot
-               # via legacy BIOS (eg, bootable USB sticks), while maintaining CD-ROM boot
-               --grub2-mbr /usr/lib/grub/i386-pc/boot_hybrid.img
-               # Specifies a boot image (using path relative to the ISO filesystem root) in the current entry of the El Torito catalog, and mark it
-               # as bootable on legacy BIOS. This executable is 32-bit, but can load 64-bit systems.
-               -eltorito-boot boot/grub/grub.eltorito.bootstrap.img
-               # "Overwrite bytes 2548 to 2555 in the current boot image by the address" of the above boot image
-               --grub2-boot-info
-               # Don't emulate floppy disk when loading this El Torito boot image (to avoid requiring image exactly "1.2, 1.44or 2.88 Mb" in size)
-               -no-emul-boot
-               # Publishes El Torito boot catalog as datafile on the ISO. This file "is not significant for the booting PC-BIOS or EFI,
-               # but it may later be read by other programs in order to learn about the available boot images"
-               -eltorito-catalog boot/boot.cat
-               # "Specifies the number of "virtual" (512-byte) sectors to load in no-emulation mode. The default is to load the entire boot file."
-               -boot-load-size 4
-               # Patches the legacy BIOS boot image (specified above with -b above) with a 56-byte "boot information table". This is supposedly
-               # important for MBR legacy boot, and is used in examples across the internet. It populates the "Block address of the Primary Volume
-               # Descriptor, block address of the boot image file, size of the boot image file"
-               -boot-info-table
-               # Specifies a boot image file (using path relative to the ISO filesystem root) to be mentioned in the current entry of the El Torito
-               # boot catalog and mark suitable as EFI.  
-               # Remember, "EFI systems normally boot from optical discs by reading a FAT image file and treating that file as an EFI System Partition"
-               #
-               # Please note, internally to xorrisofs this command first runs -eltorito-alt-boot (which finalizes the previously specified El Torito boot
-               # catalog entry), then starts a second El Torito boot parameters set (up to 63 possible per ISO9660 filesystem), then specifies the
-               # boot image file and marks it as suitable for EFI, then uses --no-emul-boot to stop floppy disk emulation (see above), then finalizes this
-               # newly defined El Torito boot catalog entry.
-               --efi-boot "boot/esp.img"
-               # Exposes the EFI System Partition (ESP) image (specified above) in the GPT (GUID Partition Table) the ESP. In other words, exposes
-               # the FAT partition that a computer's EFI firmware reads when booting from a USB stick (as opposed to the optical media case which boots
-               # using EFI by reading the ESP from an image file)
-               -efi-boot-part --efi-boot-image
                # Use contents of the specified directory as the ISO filesystem root
                "$BUILD_DIRECTORY/image/"
              )
-# Create ISO image (part 1/4), with --boot-info-table argument modifying the El Torito boot image used for legacy BIOS booting (see comment above)
-xorrisofs "${xorrisofs_args[@]}"
+if [ "$ARCH" == "amd64" ] || [ "$ARCH" == "i386" ]; then
+    xorrisofs_args+=(
+                     # Installs GRUB2 into the Master Boot Record (MBR) present within the ISO9660 "System Area", in order to support for disk boot
+                     # via legacy BIOS (eg, bootable USB sticks), while maintaining CD-ROM boot
+                     --grub2-mbr /usr/lib/grub/i386-pc/boot_hybrid.img
+                     # Specifies a boot image (using path relative to the ISO filesystem root) in the current entry of the El Torito catalog, and mark it
+                     # as bootable on legacy BIOS. This executable is 32-bit, but can load 64-bit systems.
+                     -eltorito-boot boot/grub/grub.eltorito.bootstrap.img
+                     # "Overwrite bytes 2548 to 2555 in the current boot image by the address" of the above boot image
+                     --grub2-boot-info
+                     # Don't emulate floppy disk when loading this El Torito boot image (to avoid requiring image exactly "1.2, 1.44or 2.88 Mb" in size)
+                     -no-emul-boot
+                     # Publishes El Torito boot catalog as datafile on the ISO. This file "is not significant for the booting PC-BIOS or EFI,
+                     # but it may later be read by other programs in order to learn about the available boot images"
+                     -eltorito-catalog boot/boot.cat
+                     # "Specifies the number of "virtual" (512-byte) sectors to load in no-emulation mode. The default is to load the entire boot file."
+                     -boot-load-size 4
+                     # Patches the legacy BIOS boot image (specified above with -b above) with a 56-byte "boot information table". This is supposedly
+                     # important for MBR legacy boot, and is used in examples across the internet. It populates the "Block address of the Primary Volume
+                     # Descriptor, block address of the boot image file, size of the boot image file"
+                     -boot-info-table
+                     # Specifies a boot image file (using path relative to the ISO filesystem root) to be mentioned in the current entry of the El Torito
+                     # boot catalog and mark suitable as EFI.
+                     --efi-boot "boot/esp.img"
+                     # Exposes the EFI System Partition (ESP) image (specified above) in the GPT (GUID Partition Table) the ESP. In other words, exposes
+                     # the FAT partition that a computer's EFI firmware reads when booting from a USB stick (as opposed to the optical media case which boots
+                     # using EFI by reading the ESP from an image file)
+                     -efi-boot-part --efi-boot-image
+                    )
 
-# Extract from the ISO image the El Torito boot image used for legacy BIOS booting, as it has been modified by --boot-info-table (part 2/4)
-TEMP_MOUNT_DIR=$(mktemp --directory --suffix $RESCUEZILLA_ISO_FILENAME.temp.mount.dir)
-mount "$BUILD_DIRECTORY/$RESCUEZILLA_ISO_FILENAME" "$TEMP_MOUNT_DIR"
-cp "$TEMP_MOUNT_DIR/boot/grub/grub.eltorito.bootstrap.img" "$BUILD_DIRECTORY/image/boot/grub/grub.eltorito.bootstrap.img"
-umount $TEMP_MOUNT_DIR
-rmdir $TEMP_MOUNT_DIR
+    # Create ISO image (part 1/4), with --boot-info-table argument modifying the El Torito boot image used for legacy BIOS booting (see comment above)
+    xorrisofs "${xorrisofs_args[@]}"
+
+    # Extract from the ISO image the El Torito boot image used for legacy BIOS booting, as it has been modified by --boot-info-table (part 2/4)
+    TEMP_MOUNT_DIR=$(mktemp --directory --suffix $RESCUEZILLA_ISO_FILENAME.temp.mount.dir)
+    mount "$BUILD_DIRECTORY/$RESCUEZILLA_ISO_FILENAME" "$TEMP_MOUNT_DIR"
+    cp "$TEMP_MOUNT_DIR/boot/grub/grub.eltorito.bootstrap.img" "$BUILD_DIRECTORY/image/boot/grub/grub.eltorito.bootstrap.img"
+    umount $TEMP_MOUNT_DIR
+    rmdir $TEMP_MOUNT_DIR
+
+elif [[ "$ARCH" == "arm64" ]]; then
+    xorrisofs_args+=(
+                     # UEFI boot support from the EFI System Partition image.
+                     --efi-boot "boot/esp.img"
+                     -efi-boot-part --efi-boot-image
+                    )
+else
+    echo "Unsupported ARCH for xorrisofs build: $ARCH"
+    exit 1
+fi
 
 # Generate an md5sum of all files, including the MBR boot image now modified by --boot-info-table. (part 3/4)
 find . -type f -print0 | xargs -0 md5sum | grep -v "./md5sum.txt" > md5sum.txt

--- a/src/scripts/chroot-steps-part-1.sh
+++ b/src/scripts/chroot-steps-part-1.sh
@@ -323,6 +323,8 @@ common_pkgs=("discover"
              "casper"
              "openbox"
              "lightdm"
+             # lightdm complains on arm64 when this is missing
+	     "accountsservice"
              # Firmware package for NVidia cards from ~2009 (newer cards have firmware in the kernel)
              "nouveau-firmware"
              "x11-xserver-utils"

--- a/src/scripts/chroot-steps-part-1.sh
+++ b/src/scripts/chroot-steps-part-1.sh
@@ -386,7 +386,6 @@ common_pkgs=("discover"
              "xfsdump"
              "xfsprogs"
              "udftools"
-             "grub-pc-bin"
              "grub2-common"
              "${language_pack_gnome_base_pkg[@]}"
              "qemu-utils"
@@ -401,6 +400,11 @@ common_pkgs=("discover"
 # Install openssh-server only if the IS_INTEGRATION_TEST variable is enable
 if  [ "$IS_INTEGRATION_TEST" == "true" ]; then
     common_pkgs=("${common_pkgs[@]}" "openssh-server")
+fi
+
+# grub-pc-bin is x86-only (BIOS boot support), not applicable on ARM64
+if  [ "$ARCH" == "amd64" ] || [ "$ARCH" == "i386" ]; then
+    common_pkgs=("${common_pkgs[@]}" "grub-pc-bin")
 fi
 
 if    [ "$CODENAME" == "bionic" ]; then

--- a/src/scripts/chroot-steps-part-1.sh
+++ b/src/scripts/chroot-steps-part-1.sh
@@ -222,6 +222,30 @@ pkgs_specific_to_ubuntu2404_noble=(
                        "util-linux-extra"
 )
 
+pkgs_specific_to_ubuntu2404_noble_arm64=(
+                       "linux-generic"
+                       "xserver-xorg"
+                       "xserver-xorg-video-all"
+                       "xserver-xorg-video-qxl"
+                       "xserver-xorg-video-mga"
+                       "xserver-xorg-input-libinput"
+                        # Packages which may assist users needing to do a GRUB repair (64-bit EFI)
+                       "shim-signed"
+                       # Dependency for Rescuezilla Image Explorer
+                       "nbdkit"
+                       # Replaces exfat-utils
+                       "exfatprogs"
+                       # Add support for crypto volumes mount (luks, bitlocker, crypt)
+                       "libblockdev-crypto3"
+                       # "Legacy "local authority" (.pkla) backend for polkitd" required so polkit works on Mantic
+                       # FIXME: Can probably remove with the recent introduction of new Javascript-based rules file
+                       "polkitd-pkla"
+                       "reiser4progs"
+                       "python3-whichcraft"
+                       # Needed for 'hwclock' package used by "rc-local.service", moved from base "util-linux" since Ubuntu 23.10 (Mantic)
+                       "util-linux-extra"
+)
+
 # Languages on the system
 lang_codes=(
              "ar"
@@ -407,7 +431,9 @@ if  [ "$ARCH" == "amd64" ] || [ "$ARCH" == "i386" ]; then
     common_pkgs=("${common_pkgs[@]}" "grub-pc-bin")
 fi
 
-if    [ "$CODENAME" == "bionic" ]; then
+if    [ "$CODENAME" == "noble" ] && [ "$ARCH" == "arm64" ]; then
+  apt_pkg_list=("${pkgs_specific_to_ubuntu2404_noble_arm64[@]}" "${common_pkgs[@]}")
+elif  [ "$CODENAME" == "bionic" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu1804_bionic_32bit[@]}" "${common_pkgs[@]}")
 elif  [ "$CODENAME" == "focal" ]; then
   apt_pkg_list=("${pkgs_specific_to_ubuntu2004_focal[@]}" "${common_pkgs[@]}")


### PR DESCRIPTION
Adds ability to build an ARM64 build

There were previous requests for this:
* https://github.com/rescuezilla/rescuezilla/issues/226
* https://github.com/rescuezilla/rescuezilla/issues/233

Notably #233 contains a branch attempting the same thing but which got rid of the AMD64 build in the process. I evaluated the changes but they were unfortuantely not mergable and did a lot of things at the GitHub Actions level that ideally would happen in `build.sh`. That branch had some good ideas like using qemu static binaries for cross compilation (which I haven't done here yet).

This PR is a separate implementation of ARM64 support not based on that.

# Testing

On a Raspberry Pi 4B, am able to a build.

Eg, build and launch Docker:
```
make docker-build
make docker-run
make docker-shell
```

Then create a build
```
make noble-arm64
```

This creates an ARM64 bootable ISO image, that I am able to boot with using virt-manager.

# Issues

* The GRUB menu is text-only but language menu is selectable
* Does not start X window session: `lightdm` does not start successfully

# Next steps

This is just the first step. Before release of ARM64 version of Rescuezilla, a large number of things need to be done:

* Fix the issues above
* Integrate build Rescuezilla GitHub Actions CI pipeline (likely using qemu static binary for cross-compilation)
* Start expanding how Rescuezilla's actual graphical app works (eg, questions about GRUB reinstallation cross-platform etc)
* Expand integration test scripts (which is heavily geared towards VirtualBox right now which is not available on ARM)
